### PR TITLE
[DAY-6] Fix favicon and logo paths for GitHub Pages

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -21,7 +21,7 @@
             <a class="app__brand" routerLink="/">
                 <img
                     class="app__brand-mark"
-                    [src]="themeService.theme() === 'light' ? '/logo-light.svg' : '/favicon.svg'"
+                    [src]="themeService.theme() === 'light' ? 'logo-light.svg' : 'favicon.svg'"
                     width="40"
                     height="40"
                     alt=""

--- a/src/app/core/services/theme.service.ts
+++ b/src/app/core/services/theme.service.ts
@@ -6,8 +6,9 @@ import { THEME_STORAGE_KEY, type ThemeId } from '../theme.constants';
 const META_THEME_COLOR_DARK = '#0f172a';
 const META_THEME_COLOR_LIGHT = '#f8fafc';
 
-const FAVICON_DARK = '/favicon.svg';
-const FAVICON_LIGHT = '/logo-light.svg';
+/** Relative to `<base href>` so GitHub Pages subpath deploys resolve correctly. */
+const FAVICON_DARK = 'favicon.svg';
+const FAVICON_LIGHT = 'logo-light.svg';
 
 function readStoredTheme(): ThemeId | null {
     try {

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Karkas helps developers practice technical interview answers with a study guide, timed sessions, and local progress tracking.">
   <meta id="app-theme-color" name="theme-color" content="#0f172a">
-  <link id="app-favicon" rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link id="app-favicon" rel="icon" type="image/svg+xml" href="favicon.svg">
   <script>
     (function () {
       try {
@@ -22,7 +22,7 @@
           }
           var fav = document.getElementById('app-favicon');
           if (fav) {
-            fav.setAttribute('href', v === 'light' ? '/logo-light.svg' : '/favicon.svg');
+            fav.setAttribute('href', v === 'light' ? 'logo-light.svg' : 'favicon.svg');
           }
         }
       } catch (e) {


### PR DESCRIPTION
Uses asset URLs relative to \<base href>\ instead of root-absolute paths, so favicon and header logo load correctly when the app is deployed under a subpath (e.g. GitHub Pages).

Made with [Cursor](https://cursor.com)