### PR TITLE
feat(plan): last studied date per topic

### DIFF
--- a/src/app/features/plan/pages/plan-page/plan-page.component.html
+++ b/src/app/features/plan/pages/plan-page/plan-page.component.html
@@ -98,6 +98,25 @@
                                     (click)="$event.preventDefault(); todayPlan.toggleTopicSelected(topicId(cat, sub))"
                                 />
                                 <span class="plan__topic-text">{{ (labelKey(sub)) | translate }}</span>
+                                @if (topicLastStudiedHint(cat, sub); as hint) {
+                                    <span
+                                        class="plan__topic-date"
+                                        [class.plan__topic-date--empty]="hint.kind === 'none'"
+                                        [attr.aria-label]="lastStudiedDateAria(hint)"
+                                    >
+                                        @switch (hint.kind) {
+                                            @case ('none') {
+                                                {{ 'plan.lastStudiedNever' | translate }}
+                                            }
+                                            @case ('today') {
+                                                {{ 'plan.lastStudiedToday' | translate }}
+                                            }
+                                            @case ('past') {
+                                                {{ hint.dateStr }}
+                                            }
+                                        }
+                                    </span>
+                                }
                                 @if (topicStatusKey(cat, sub); as statusKey) {
                                     <span
                                         class="plan__topic-status"

--- a/src/app/features/plan/pages/plan-page/plan-page.component.scss
+++ b/src/app/features/plan/pages/plan-page/plan-page.component.scss
@@ -233,7 +233,7 @@
 .plan__topic-label {
     display: flex;
     align-items: flex-start;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: 0.55rem;
     cursor: pointer;
     font-size: 0.9rem;
@@ -250,11 +250,28 @@
 
 .plan__topic-text {
     flex: 1;
+    min-width: 0;
+}
+
+.plan__topic-date {
+    flex: 0 0 auto;
+    max-width: 42%;
+    text-align: right;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--it-text-muted);
+    line-height: 1.45;
+    white-space: nowrap;
+}
+
+.plan__topic-date--empty {
+    font-weight: 500;
+    opacity: 0.65;
 }
 
 .plan__topic-status {
     flex: 0 0 auto;
-    margin-left: 1.65rem;
+    margin-left: 0;
     padding: 0.08rem 0.45rem;
     border-radius: 999px;
     border: 1px solid var(--it-border);

--- a/src/app/features/plan/pages/plan-page/plan-page.component.ts
+++ b/src/app/features/plan/pages/plan-page/plan-page.component.ts
@@ -1,12 +1,19 @@
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { RouterLink } from '@angular/router';
-import { TranslatePipe } from '@ngx-translate/core';
+import { NavigationEnd, Router, RouterLink } from '@angular/router';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { filter } from 'rxjs';
 
+import { ActivityService } from '../../../../core/services/activity.service';
+import { ProgressService } from '../../../../core/services/progress.service';
 import { TodayPlanService } from '../../../../core/services/today-plan.service';
 import { QuestionService } from '../../../../core/services/question.service';
 import type { Question } from '../../../../shared/models/question.model';
 import { topicIdFromParts } from '../../../../shared/utils/topic-key.utils';
+import {
+    buildTopicLastStudiedHintMap,
+    type TopicLastStudiedHint
+} from '../../../../shared/utils/topic-last-studied.utils';
 import { buildStudyGuideSections, type StudyCategorySection, type StudySubtopicSection } from '../../../study/study-guide-grouping';
 
 @Component({
@@ -18,7 +25,14 @@ import { buildStudyGuideSections, type StudyCategorySection, type StudySubtopicS
 })
 export class PlanPageComponent {
     private readonly questionService = inject(QuestionService);
+    private readonly progressService = inject(ProgressService);
+    private readonly activityService = inject(ActivityService);
+    private readonly translate = inject(TranslateService);
+    private readonly router = inject(Router);
     protected readonly todayPlan = inject(TodayPlanService);
+
+    /** Recomputes last-studied hints when locale, navigation, or stored activity/progress may have changed. */
+    private readonly lastStudiedRefresh = signal(0);
 
     protected readonly questions = signal<Question[]>([]);
     protected readonly loading = signal(true);
@@ -35,8 +49,35 @@ export class PlanPageComponent {
         return this.todayPlan.selectedTopicIds().filter((id) => studied.has(id));
     });
 
+    protected readonly topicLastStudiedById = computed(() => {
+        this.lastStudiedRefresh();
+        this.questions();
+        this.activityService.activityMap();
+        return buildTopicLastStudiedHintMap(
+            this.questions(),
+            this.activityService.activityMap(),
+            this.progressService.getProgress(),
+            this.translate.currentLang ?? 'en'
+        );
+    });
+
     constructor() {
         this.todayPlan.syncCalendarDay();
+
+        this.translate.onLangChange.pipe(takeUntilDestroyed()).subscribe(() => {
+            this.lastStudiedRefresh.update((n) => n + 1);
+        });
+
+        this.router.events
+            .pipe(
+                filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+                takeUntilDestroyed()
+            )
+            .subscribe(() => {
+                if (this.router.url.includes('/plan')) {
+                    this.lastStudiedRefresh.update((n) => n + 1);
+                }
+            });
 
         this.questionService
             .getQuestions()
@@ -72,6 +113,21 @@ export class PlanPageComponent {
             return null;
         }
         return this.todayPlan.isStudied(id) ? 'plan.statusInPractice' : 'plan.statusToStudy';
+    }
+
+    protected topicLastStudiedHint(cat: StudyCategorySection, sub: StudySubtopicSection): TopicLastStudiedHint {
+        return this.topicLastStudiedById().get(this.topicId(cat, sub)) ?? { kind: 'none' };
+    }
+
+    protected lastStudiedDateAria(hint: TopicLastStudiedHint): string {
+        if (hint.kind === 'none') {
+            return this.translate.instant('plan.lastStudiedNeverAria');
+        }
+        const dateLabel =
+            hint.kind === 'today'
+                ? this.translate.instant('plan.lastStudiedToday')
+                : hint.dateStr;
+        return this.translate.instant('plan.lastStudiedAria', { date: dateLabel });
     }
 
     /** Subtopic string from `category:subtopic` id. */

--- a/src/app/shared/utils/topic-last-studied.utils.ts
+++ b/src/app/shared/utils/topic-last-studied.utils.ts
@@ -1,0 +1,133 @@
+import type { DailyActivity } from '../models/activity.model';
+import type { Progress } from '../models/progress.model';
+import type { Question } from '../models/question.model';
+import { topicIdFromParts } from './topic-key.utils';
+
+/** Shown next to a topic on the Plan page (last read / practice touch). */
+export type TopicLastStudiedHint =
+    | { kind: 'none' }
+    | { kind: 'today' }
+    | { kind: 'past'; dateStr: string };
+
+function isSameLocalCalendarDay(a: Date, b: Date): boolean {
+    return (
+        a.getFullYear() === b.getFullYear() &&
+        a.getMonth() === b.getMonth() &&
+        a.getDate() === b.getDate()
+    );
+}
+
+function parseLocalYmdToDate(ymd: string): Date | null {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(ymd.trim());
+    if (!m) {
+        return null;
+    }
+    const y = Number(m[1]);
+    const mo = Number(m[2]) - 1;
+    const d = Number(m[3]);
+    const dt = new Date(y, mo, d);
+    return Number.isNaN(dt.getTime()) ? null : dt;
+}
+
+/**
+ * For each topic id, the latest calendar day it appeared in `coveredTopicIds`
+ * (mark studied or answering in Practice).
+ */
+export function lastCoveredYmdByTopic(activityMap: ReadonlyMap<string, DailyActivity>): Map<string, string> {
+    const dates = [...activityMap.keys()].sort((a, b) => a.localeCompare(b));
+    const result = new Map<string, string>();
+    for (const date of dates) {
+        const row = activityMap.get(date);
+        for (const tid of row?.coveredTopicIds ?? []) {
+            if (typeof tid === 'string' && tid.trim()) {
+                result.set(tid.trim(), date);
+            }
+        }
+    }
+    return result;
+}
+
+/** Latest `lastAnswered` ISO string per topic from practice progress. */
+export function lastPracticeIsoByTopic(questions: Question[], progress: Progress[]): Map<string, string> {
+    const qById = new Map(questions.map((q) => [q.id, q] as const));
+    const byTopic = new Map<string, string>();
+    for (const row of progress) {
+        if (!row.lastAnswered) {
+            continue;
+        }
+        const q = qById.get(row.questionId);
+        if (!q) {
+            continue;
+        }
+        const tid = topicIdFromParts(q.category, q.subtopic);
+        const prev = byTopic.get(tid);
+        if (!prev || row.lastAnswered > prev) {
+            byTopic.set(tid, row.lastAnswered);
+        }
+    }
+    return byTopic;
+}
+
+function mergeLastEngagement(ymd: string | undefined, iso: string | undefined): Date | null {
+    let best: Date | null = null;
+    if (ymd) {
+        const d = parseLocalYmdToDate(ymd);
+        if (d) {
+            best = d;
+        }
+    }
+    if (iso) {
+        const d = new Date(iso);
+        if (!Number.isNaN(d.getTime())) {
+            if (!best || d > best) {
+                best = d;
+            }
+        }
+    }
+    return best;
+}
+
+function formatShortStudyDate(d: Date, lang: 'ru-RU' | 'en-GB'): string {
+    const now = new Date();
+    const opts: Intl.DateTimeFormatOptions = {
+        day: 'numeric',
+        month: 'short'
+    };
+    if (d.getFullYear() !== now.getFullYear()) {
+        opts.year = 'numeric';
+    }
+    return d.toLocaleDateString(lang, opts);
+}
+
+/** One hint per topic that appears in the question catalog. */
+export function buildTopicLastStudiedHintMap(
+    questions: Question[],
+    activityMap: ReadonlyMap<string, DailyActivity>,
+    progress: Progress[],
+    translateLang: string
+): ReadonlyMap<string, TopicLastStudiedHint> {
+    const covered = lastCoveredYmdByTopic(activityMap);
+    const practice = lastPracticeIsoByTopic(questions, progress);
+    const lang: 'ru-RU' | 'en-GB' = translateLang?.toLowerCase().startsWith('ru') ? 'ru-RU' : 'en-GB';
+
+    const topicIds = new Set<string>();
+    for (const q of questions) {
+        topicIds.add(topicIdFromParts(q.category, q.subtopic));
+    }
+
+    const result = new Map<string, TopicLastStudiedHint>();
+    for (const tid of topicIds) {
+        const d = mergeLastEngagement(covered.get(tid), practice.get(tid));
+        if (!d) {
+            result.set(tid, { kind: 'none' });
+            continue;
+        }
+        const now = new Date();
+        if (isSameLocalCalendarDay(d, now)) {
+            result.set(tid, { kind: 'today' });
+        } else {
+            result.set(tid, { kind: 'past', dateStr: formatShortStudyDate(d, lang) });
+        }
+    }
+    return result;
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -74,7 +74,11 @@
         "statusToStudy": "To study",
         "statusInPractice": "In practice",
         "remove": "Remove",
-        "removeAria": "Remove {{topic}} from today’s plan"
+        "removeAria": "Remove {{topic}} from today’s plan",
+        "lastStudiedNever": "—",
+        "lastStudiedNeverAria": "No recorded study or practice in this topic yet",
+        "lastStudiedToday": "Today",
+        "lastStudiedAria": "Last activity in this topic: {{date}}"
     },
     "heatmap": {
         "heading": "Activity",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -74,7 +74,11 @@
         "statusToStudy": "К изучению",
         "statusInPractice": "В практике",
         "remove": "Убрать",
-        "removeAria": "Убрать «{{topic}}» из плана на сегодня"
+        "removeAria": "Убрать «{{topic}}» из плана на сегодня",
+        "lastStudiedNever": "—",
+        "lastStudiedNeverAria": "Пока нет записей об изучении или практике по этой теме",
+        "lastStudiedToday": "Сегодня",
+        "lastStudiedAria": "Последняя активность по теме: {{date}}"
     },
     "heatmap": {
         "heading": "Активность",


### PR DESCRIPTION
Adds a date column on the Plan page showing when each subtopic was last touched (activity + practice). Includes EN/RU strings and \	opic-last-studied.utils\ for merging covered-topic days with per-question last practice.

Made with [Cursor](https://cursor.com)