### PR TITLE
[DAY-9] fix(banner): hide retry banner as topics are covered today

### DIFF
--- a/.cursor/rules/open-browser-after-bug-fix.mdc
+++ b/.cursor/rules/open-browser-after-bug-fix.mdc
@@ -1,0 +1,11 @@
+---
+description: Open the internal browser to verify the fix after fixing a bug
+alwaysApply: true
+---
+
+# Open Browser After Bug Fix
+
+After fixing a bug, always open the internal browser to visually verify the fix using the `cursor-ide-browser` MCP:
+
+1. Navigate to the relevant page (e.g. `http://localhost:4200`) using `browser_navigate`
+2. Take a screenshot with `browser_take_screenshot` to confirm the fix is visible

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -32,15 +32,22 @@ export class App {
     protected readonly navMenuOpen = signal(false);
     protected readonly retryBannerDismissed = signal(false);
 
-    /** Topic IDs (category:subtopic) where the best rating yesterday was didntKnow or partial. */
+    /**
+     * Topic IDs (category:subtopic) where the best rating yesterday was didntKnow or partial
+     * AND the topic has not yet been covered today. A topic is considered covered when the user
+     * answers any of its questions in the Quiz OR marks it as studied in the Study Guide
+     * (both paths write to `coveredTopicIds`). The banner disappears automatically as topics
+     * are worked through.
+     */
     protected readonly retryTopicIds = computed(() => {
+        const activityMap = this.activityService.activityMap();
         const yesterday = this.yesterdayYmd();
-        const row = this.activityService.activityMap().get(yesterday);
-        if (!row?.practiceRatingBest) {
+        const yesterdayRow = activityMap.get(yesterday);
+        if (!yesterdayRow?.practiceRatingBest) {
             return [];
         }
         const failedQIds = new Set<number>();
-        for (const [qIdStr, rating] of Object.entries(row.practiceRatingBest)) {
+        for (const [qIdStr, rating] of Object.entries(yesterdayRow.practiceRatingBest)) {
             if (rating === 'didntKnow' || rating === 'partial') {
                 failedQIds.add(Number(qIdStr));
             }
@@ -54,7 +61,13 @@ export class App {
                 topicIds.add(`${q.category}:${q.subtopic}`);
             }
         }
-        return [...topicIds];
+        if (topicIds.size === 0) {
+            return [];
+        }
+        // Remove topics already covered today via Quiz practice or Study Guide "Mark as studied"
+        const todayRow = activityMap.get(formatLocalYmd(new Date()));
+        const todayCovered = new Set(todayRow?.coveredTopicIds ?? []);
+        return [...topicIds].filter((tid) => !todayCovered.has(tid));
     });
 
     protected readonly showRetryBanner = computed(


### PR DESCRIPTION
## Summary
- Fixed retry banner not disappearing after the user practices recommended topics
- Replaced per-question `practiceRatingBest` check with `coveredTopicIds` check, which is updated by both the Quiz (on self-rating) and the Study Guide (on "Mark as studied")
- Banner now reactively drops each topic as it is covered today, disappearing entirely once all yesterday's failed topics are resolved

## Test plan
- [ ] Have trouble topics from yesterday (didntKnow or partial ratings)
- [ ] Confirm banner shows on app load
- [ ] Practice a topic in the Quiz and self-rate — confirm its topic is removed from the banner count
- [ ] Mark a topic as studied in the Study Guide — confirm its topic is removed from the banner count
- [ ] Resolve all topics — confirm banner disappears automatically without manual dismissal
