### PR TITLE
fix: show retry banner for all past weak topics, not just yesterday

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -33,25 +33,28 @@ export class App {
     protected readonly retryBannerDismissed = signal(false);
 
     /**
-     * Topic IDs (category:subtopic) where the best rating yesterday was didntKnow or partial
-     * AND the topic has not yet been covered today. A topic is considered covered when the user
-     * answers any of its questions in the Quiz OR marks it as studied in the Study Guide
-     * (both paths write to `coveredTopicIds`). The banner disappears automatically as topics
-     * are worked through.
+     * Topic IDs (category:subtopic) where the best rating on any past day was didntKnow or
+     * partial AND the topic has not yet been covered today. A topic is considered covered when
+     * the user answers any of its questions in the Quiz OR marks it as studied in the Study
+     * Guide (both paths write to `coveredTopicIds`). The banner disappears automatically as
+     * topics are worked through.
      */
     protected readonly retryTopicIds = computed(() => {
         const activityMap = this.activityService.activityMap();
-        const yesterday = this.yesterdayYmd();
-        const yesterdayRow = activityMap.get(yesterday);
-        if (!yesterdayRow?.practiceRatingBest) {
-            return [];
-        }
+        const todayYmd = formatLocalYmd(new Date());
         const failedQIds = new Set<number>();
-        for (const [qIdStr, rating] of Object.entries(yesterdayRow.practiceRatingBest)) {
-            if (rating === 'didntKnow' || rating === 'partial') {
-                failedQIds.add(Number(qIdStr));
+
+        for (const [dateKey, row] of activityMap) {
+            if (dateKey >= todayYmd || !row.practiceRatingBest) {
+                continue;
+            }
+            for (const [qIdStr, rating] of Object.entries(row.practiceRatingBest)) {
+                if (rating === 'didntKnow' || rating === 'partial') {
+                    failedQIds.add(Number(qIdStr));
+                }
             }
         }
+
         if (failedQIds.size === 0) {
             return [];
         }
@@ -64,8 +67,7 @@ export class App {
         if (topicIds.size === 0) {
             return [];
         }
-        // Remove topics already covered today via Quiz practice or Study Guide "Mark as studied"
-        const todayRow = activityMap.get(formatLocalYmd(new Date()));
+        const todayRow = activityMap.get(todayYmd);
         const todayCovered = new Set(todayRow?.coveredTopicIds ?? []);
         return [...topicIds].filter((tid) => !todayCovered.has(tid));
     });
@@ -129,11 +131,5 @@ export class App {
 
     private normalizeLang(lang: string | undefined): 'en' | 'ru' {
         return lang === 'ru' ? 'ru' : 'en';
-    }
-
-    private yesterdayYmd(): string {
-        const d = new Date();
-        d.setDate(d.getDate() - 1);
-        return formatLocalYmd(d);
     }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -4,7 +4,7 @@
         "navAria": "Main",
         "menuToggle": "Open menu",
         "menuClose": "Close menu",
-        "retryBannerMsg": "You had trouble with {{count}} topic(s) yesterday.",
+        "retryBannerMsg": "You had trouble with {{count}} topic(s) recently.",
         "retryBannerLink": "Review in Study guide →",
         "retryBannerClose": "Dismiss suggestion"
     },
@@ -62,7 +62,7 @@
         "lastPractice": "Last practice: {{date}}",
         "lastPracticeAria": "Last answered in Practice on {{date}}",
         "expandCollapseAll": "Expand / collapse all",
-        "filteredRetryBanner": "Showing topics you had trouble with yesterday.",
+        "filteredRetryBanner": "Showing topics you had trouble with recently.",
         "filteredRetryClear": "Show all topics"
     },
     "plan": {

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -4,7 +4,7 @@
         "navAria": "Основная навигация",
         "menuToggle": "Открыть меню",
         "menuClose": "Закрыть меню",
-        "retryBannerMsg": "Вчера были затруднения с {{count}} темой(-ами).",
+        "retryBannerMsg": "Недавно были затруднения с {{count}} темой(-ами).",
         "retryBannerLink": "Повторить в справочнике →",
         "retryBannerClose": "Скрыть подсказку"
     },
@@ -62,7 +62,7 @@
         "lastPractice": "Последняя практика: {{date}}",
         "lastPracticeAria": "Последний ответ в практике: {{date}}",
         "expandCollapseAll": "Развернуть / свернуть всё",
-        "filteredRetryBanner": "Показаны темы, с которыми были затруднения вчера.",
+        "filteredRetryBanner": "Показаны темы, с которыми были затруднения недавно.",
         "filteredRetryClear": "Показать все темы"
     },
     "plan": {


### PR DESCRIPTION
## Summary
- The retry notification banner now scans all past days for failed topics instead of only yesterday
- This ensures the banner stays visible even if the user skips a day, as long as weak topics remain unaddressed
- Updated EN and RU translation strings to say 'recently' instead of 'yesterday'

## Test plan
- [ ] Verify the retry banner appears when there are weak topics from any past day (not just yesterday)
- [ ] Verify the banner disappears when all weak topics are covered today
- [ ] Verify dismiss button still works
- [ ] Check EN and RU translations display correctly