### PR TITLE
Fix issue #14: Hide 'Review in Study guide' link when already on Study Guide page

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -147,13 +147,15 @@
             <span class="app__retry-banner-text">
                 {{ 'app.retryBannerMsg' | translate: { count: retryTopicIds().length } }}
             </span>
-            <a
-                [routerLink]="['/study']"
-                [queryParams]="retryStudyQueryParams()"
-                class="app__retry-banner-link"
-            >
-                {{ 'app.retryBannerLink' | translate }}
-            </a>
+            @if (!isOnStudyPage()) {
+                <a
+                    [routerLink]="['/study']"
+                    [queryParams]="retryStudyQueryParams()"
+                    class="app__retry-banner-link"
+                >
+                    {{ 'app.retryBannerLink' | translate }}
+                </a>
+            }
             <button
                 type="button"
                 class="app__retry-banner-close"

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -110,6 +110,9 @@ export class App {
         return !this.retryBannerDismissed() && this.retryTopicIds().length > 0;
     });
 
+    /** True when the user is already on the Study Guide page — hides the redundant retry link. */
+    protected readonly isOnStudyPage = computed(() => this.locationPath().startsWith('/study'));
+
     /** Main nav: interview block hidden while browsing sociology routes. */
     protected readonly showInterviewNavSection = computed(() => !this.locationPath().startsWith('/sociology'));
 


### PR DESCRIPTION
## Summary
- Adds `isOnStudyPage` computed signal to `app.ts` that checks if the current route starts with `/study`
- Wraps the "Review in Study guide →" link in `@if (!isOnStudyPage())` so it is hidden when the user is already there
- Banner message and dismiss button remain visible regardless of route

Closes #14