### PR TITLE
  Fix issue #23: Add "Your strongest topics" section to dashboard

### DIFF
--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.html
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.html
@@ -132,6 +132,31 @@
                 }
             </article>
 
+            <article class="dashboard__card">
+                <h2 class="dashboard__card-title">{{ 'dashboard.bestTopics.title' | translate }}</h2>
+                @if (bestTopicsView().length === 0) {
+                    <p class="dashboard__hint">{{ 'dashboard.bestTopics.empty' | translate }}</p>
+                } @else {
+                    <ul class="dashboard__best-list">
+                        @for (entry of bestTopicsView(); track entry.id) {
+                            <li class="dashboard__best-item">
+                                <div class="dashboard__best-info">
+                                    <span class="dashboard__best-name">{{
+                                        ('subtopics.' + entry.subtopic) | translate
+                                    }}</span>
+                                    <span class="dashboard__best-badge dashboard__best-badge--{{ entry.category }}">{{
+                                        ('category.' + entry.category) | translate
+                                    }}</span>
+                                </div>
+                                <span class="dashboard__best-pct">{{
+                                    'dashboard.bestTopics.nailedPct' | translate: { pct: entry.nailedPct }
+                                }}</span>
+                            </li>
+                        }
+                    </ul>
+                }
+            </article>
+
             <article class="dashboard__card dashboard__card--wide">
                 <h2 class="dashboard__card-title">{{ 'dashboard.practiceRatingsHeading' | translate }}</h2>
                 <p class="dashboard__hint dashboard__ratings-intro">{{ 'dashboard.practiceRatingsIntro' | translate }}</p>

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.scss
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.scss
@@ -210,6 +210,77 @@
     color: var(--it-accent);
 }
 
+.dashboard__best-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.dashboard__best-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.5rem 0.65rem;
+    border-radius: 0.5rem;
+    background: var(--it-dashboard-streak-bg);
+    border: 1px solid var(--it-dashboard-streak-border);
+}
+
+.dashboard__best-info {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+    flex: 1;
+}
+
+.dashboard__best-name {
+    font-weight: 600;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.dashboard__best-badge {
+    flex-shrink: 0;
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.15rem 0.45rem;
+    border-radius: 0.3rem;
+    background: var(--it-border);
+    color: var(--it-text-muted);
+}
+
+.dashboard__best-badge--javascript {
+    background: color-mix(in srgb, #f7df1e 18%, var(--it-card));
+    color: color-mix(in srgb, #a07800 80%, currentColor);
+}
+
+.dashboard__best-badge--angular {
+    background: color-mix(in srgb, #dd0031 14%, var(--it-card));
+    color: color-mix(in srgb, #9b0022 80%, currentColor);
+}
+
+.dashboard__best-badge--rxjs {
+    background: color-mix(in srgb, #b7178c 14%, var(--it-card));
+    color: color-mix(in srgb, #7d0060 80%, currentColor);
+}
+
+.dashboard__best-pct {
+    flex-shrink: 0;
+    font-size: 0.88rem;
+    font-weight: 700;
+    color: var(--it-heat-1-border);
+    font-variant-numeric: tabular-nums;
+}
+
 .dashboard__ratings-intro {
     margin-bottom: 1rem;
 }

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.ts
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.ts
@@ -28,6 +28,17 @@ export interface WeakTopic {
     nailedNeeded: number;
 }
 
+export interface TopicStrengthEntry {
+    id: string;
+    category: string;
+    subtopic: string;
+    nailedPct: number;
+    nailed: number;
+    partial: number;
+    didntKnow: number;
+    total: number;
+}
+
 export interface DashboardStats {
     totalAnswered: number;
     accuracyPct: number;
@@ -114,6 +125,53 @@ export class DashboardPageComponent {
     protected readonly loading = signal(true);
     protected readonly loadError = signal(false);
 
+    private readonly questionsSignal = signal<Question[]>([]);
+
+    protected readonly bestTopicsView = computed((): TopicStrengthEntry[] => {
+        const qs = this.questionsSignal();
+        if (qs.length === 0) {
+            return [];
+        }
+        const idToTopic = new Map<string, string>();
+        for (const q of qs) {
+            idToTopic.set(String(q.id), topicIdFromParts(q.category, q.subtopic));
+        }
+        const byTopic = new Map<string, { nailed: number; partial: number; didntKnow: number }>();
+        for (const row of this.activityService.activityMap().values()) {
+            if (!row.practiceRatingBest) {
+                continue;
+            }
+            for (const [qId, rating] of Object.entries(row.practiceRatingBest)) {
+                const topicId = idToTopic.get(qId);
+                if (!topicId) {
+                    continue;
+                }
+                const agg = byTopic.get(topicId) ?? { nailed: 0, partial: 0, didntKnow: 0 };
+                if (rating === 'nailed') {
+                    agg.nailed++;
+                } else if (rating === 'partial') {
+                    agg.partial++;
+                } else if (rating === 'didntKnow') {
+                    agg.didntKnow++;
+                }
+                byTopic.set(topicId, agg);
+            }
+        }
+        const entries: TopicStrengthEntry[] = [];
+        for (const [id, agg] of byTopic) {
+            const total = agg.nailed + agg.partial + agg.didntKnow;
+            if (total === 0) {
+                continue;
+            }
+            const ci = id.indexOf(':');
+            const category = ci >= 0 ? id.slice(0, ci) : id;
+            const subtopic = ci >= 0 ? id.slice(ci + 1) : id;
+            entries.push({ id, category, subtopic, nailedPct: Math.round((agg.nailed / total) * 100), ...agg, total });
+        }
+        entries.sort((a, b) => b.nailedPct - a.nailedPct || a.id.localeCompare(b.id));
+        return entries.slice(0, 5);
+    });
+
     protected toggleMetricHelp(which: 'accuracy' | 'confidence'): void {
         this.openMetricHelp.update((current) => (current === which ? null : which));
     }
@@ -135,6 +193,7 @@ export class DashboardPageComponent {
                 next: (questions) => {
                     const progress = this.progressService.getProgress();
                     this.stats.set(this.computeStats(questions, progress));
+                    this.questionsSignal.set(questions);
                     this.loading.set(false);
                     this.loadError.set(false);
                 },

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -323,7 +323,12 @@
         "practiceRatingsTotalAnswers": "{{count}} answers total",
         "practiceRatingsEmptyDay": "No practice ratings recorded yet today.",
         "practiceRatingsEmptyAllDays": "No per-day ratings stored yet. New practice sessions will fill this in.",
-        "practiceRatingsEmptyAttempts": "No answers rated yet."
+        "practiceRatingsEmptyAttempts": "No answers rated yet.",
+        "bestTopics": {
+            "title": "Your strongest topics",
+            "empty": "No practice data yet — rate a few answers to see your strongest topics here.",
+            "nailedPct": "{{pct}}% nailed"
+        }
     },
     "answerBlocks": {
         "weak": "Weak answer",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -323,7 +323,12 @@
         "practiceRatingsTotalAnswers": "Всего ответов: {{count}}",
         "practiceRatingsEmptyDay": "Сегодня ещё нет оценок в практике.",
         "practiceRatingsEmptyAllDays": "Пока нет сохранённых дневных оценок — новые сессии практики заполнят этот блок.",
-        "practiceRatingsEmptyAttempts": "Пока ни одна оценка не сохранена."
+        "practiceRatingsEmptyAttempts": "Пока ни одна оценка не сохранена.",
+        "bestTopics": {
+            "title": "Ваши сильнейшие темы",
+            "empty": "Пока нет данных — ответьте на несколько вопросов в практике, чтобы увидеть сильнейшие темы.",
+            "nailedPct": "{{pct}}% отлично"
+        }
     },
     "answerBlocks": {
         "weak": "Слабый ответ",


### PR DESCRIPTION
  Summary

  - Closes #23
  - Adds a "Your strongest topics" card to the dashboard that ranks the top 5 topics by nailed percentage, giving users insight into
  where they are strongest
  - Ranking is derived from ActivityService's per-day best ratings (practiceRatingBest) aggregated across all stored days, so it
  reflects consistent performance rather than a single session

  Changes

  - dashboard-page.component.ts: Added TopicStrengthEntry interface; added questionsSignal to hold loaded questions reactively; added
   bestTopicsView computed signal that maps question IDs to topics via QuestionService data, aggregates nailed/partial/didntKnow
  counts per topic from the activity map, and returns the top 5 sorted by nailed % descending
  - dashboard-page.component.html: Added new card between weak topics and practice ratings; renders the ranked list with topic name,
  color-coded category badge, and nailed %; shows an encouraging empty state when no data is available yet
  - dashboard-page.component.scss: Added styles for .dashboard__best-list, .dashboard__best-item, .dashboard__best-info,
  .dashboard__best-name, .dashboard__best-badge (with per-category color variants for javascript, angular, rxjs), and
  .dashboard__best-pct
  - en.json / ru.json: Added dashboard.bestTopics.title, dashboard.bestTopics.empty, and dashboard.bestTopics.nailedPct translation
  keys

  Test plan

  - Open the dashboard after answering several questions in Practice — verify the "Your strongest topics" card appears with up to 5
  topics ranked by nailed %
  - Confirm topics with higher nailed % appear above those with lower nailed %
  - Verify each row shows the translated subtopic name, the correct category badge (JS / Angular / RxJS color), and the nailed %
  value
  - Open the dashboard with no practice history (fresh localStorage) — verify the empty-state hint is shown instead of the list
  - Switch the app language to Russian — verify both the card title and empty state render in Russian
  - Confirm the card does not appear as a link (no navigation on click), distinguishing it from the weak topics card