### PR TITLE
Hide keyboard shortcut hint on touch devices

### DIFF
--- a/src/app/features/quiz/pages/quiz-page/quiz-page.component.scss
+++ b/src/app/features/quiz/pages/quiz-page/quiz-page.component.scss
@@ -359,6 +359,12 @@
     opacity: 0.7;
 }
 
+@media (pointer: coarse) {
+    .quiz__keyboard-hint {
+        display: none;
+    }
+}
+
 .quiz__keyboard-hint--footer {
     max-width: 700px;
     align-self: center;


### PR DESCRIPTION
## Summary
- Adds `@media (pointer: coarse)` rule to hide the "Press 1 · 2 · 3 to rate" hint on touchscreen devices
- The hint is only relevant when a physical keyboard is available; on mobile it wastes space and is misleading

## Test plan
- [ ] Open quiz on a mobile device (or Chrome DevTools in touch emulation) — hint should not be visible in the rating footer
- [ ] Open quiz on desktop — hint should still appear as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)