### PR TITLE
Fix #38: Add single-step undo for quiz self-rating

### DIFF
--- a/docs/issues-priority.md
+++ b/docs/issues-priority.md
@@ -9,7 +9,7 @@ Generated 2026-05-06. Based on labels, dependencies, and effort/value assessment
 | # | Issue | Why first |
 |---|-------|-----------|
 | ~~[#58](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/58)~~ | ~~Heatmap contrast in dark mode~~ | ✅ Done — [PR #65](https://github.com/ZhannaM85/interview-trainer-angular-app/pull/65) |
-| [#38](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/38) | Undo last quiz rating | Reduces quiz frustration, self-contained |
+| ~~[#38](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/38)~~ | ~~Undo last quiz rating~~ | ✅ Done — [PR #66](https://github.com/ZhannaM85/interview-trainer-angular-app/pull/66) |
 | [#49](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/49) | Randomize question order | One-liner in QuestionService, prevents recall by position |
 | [#55](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/55) | Collapsible code examples in study guide | Big mobile UX improvement, no data changes |
 | [#54](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/54) | Bulk "Mark all as studied" in plan | Low effort, plan page already has the logic |

--- a/src/app/core/services/activity.service.ts
+++ b/src/app/core/services/activity.service.ts
@@ -108,6 +108,13 @@ export class ActivityService {
         }));
     }
 
+    undoQuestionsAnswered(): void {
+        this.updateDay(formatLocalYmd(new Date()), (row) => ({
+            ...row,
+            questionsAnswered: Math.max(0, row.questionsAnswered - 1)
+        }));
+    }
+
     bumpTopicsStudied(delta = 1): void {
         if (delta <= 0) {
             return;

--- a/src/app/core/services/progress.service.ts
+++ b/src/app/core/services/progress.service.ts
@@ -131,6 +131,24 @@ export class ProgressService {
         return this._progress();
     }
 
+    /**
+     * Reverts a previously recorded self-rating. Pass the progress snapshot captured
+     * just before calling `recordSelfRating` — null means the question had no entry yet.
+     */
+    revertProgress(questionId: number, previous: Progress | null): void {
+        this._progress.update((list) => {
+            if (previous === null) {
+                return list.filter((p) => p.questionId !== questionId);
+            }
+            const exists = list.some((p) => p.questionId === questionId);
+            if (exists) {
+                return list.map((p) => (p.questionId === questionId ? previous : p));
+            }
+            return [...list, previous];
+        });
+        this.storage.set(PROGRESS_KEY, this._progress());
+    }
+
     private loadProgress(): Progress[] {
         const raw = this.storage.get<unknown>(PROGRESS_KEY);
         if (!Array.isArray(raw)) {

--- a/src/app/core/services/question.service.ts
+++ b/src/app/core/services/question.service.ts
@@ -101,6 +101,13 @@ export class QuestionService {
         return this.queue[this.index];
     }
 
+    /** Moves the queue cursor back one position so the next getNextQuestion() call re-delivers the current question. */
+    stepBack(): void {
+        if (this.index > 0) {
+            this.index -= 1;
+        }
+    }
+
     resetQueue(): void {
         this.queue = [];
         this.index = -1;

--- a/src/app/features/quiz/pages/quiz-page/quiz-page.component.html
+++ b/src/app/features/quiz/pages/quiz-page/quiz-page.component.html
@@ -177,6 +177,15 @@
             </div>
         }
 
+        @if (phase() === 'question' && undoSnapshot()) {
+            <div class="quiz__undo-row">
+                <button type="button" class="quiz__undo-btn" (click)="onUndoRating()">
+                    ← {{ 'quiz.undoRating' | translate }}
+                </button>
+                <p class="quiz__keyboard-hint quiz__keyboard-hint--undo" aria-hidden="true">{{ 'quiz.keyboardHintUndo' | translate }}</p>
+            </div>
+        }
+
         <div class="quiz__card-wrap" [attr.data-phase]="phase()">
             @if (phase() === 'question') {
                 <div class="quiz__phase card-phase">

--- a/src/app/features/quiz/pages/quiz-page/quiz-page.component.scss
+++ b/src/app/features/quiz/pages/quiz-page/quiz-page.component.scss
@@ -441,3 +441,36 @@
     align-self: center;
     width: 100%;
 }
+
+.quiz__undo-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.quiz__undo-btn {
+    padding: 0.35rem 0.85rem;
+    border-radius: 0.6rem;
+    border: 1px solid var(--it-border);
+    background: transparent;
+    color: var(--it-text-muted);
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: border-color 0.12s ease, color 0.12s ease;
+    white-space: nowrap;
+}
+
+.quiz__undo-btn:hover {
+    border-color: var(--it-accent);
+    color: var(--it-accent);
+}
+
+.quiz__undo-btn:focus-visible {
+    outline: 2px solid var(--it-focus);
+    outline-offset: 2px;
+}
+
+.quiz__keyboard-hint--undo {
+    flex: 1;
+}

--- a/src/app/features/quiz/pages/quiz-page/quiz-page.component.ts
+++ b/src/app/features/quiz/pages/quiz-page/quiz-page.component.ts
@@ -8,6 +8,7 @@ import { ActivityService } from '../../../../core/services/activity.service';
 import { ProgressService, SCORE_BY_RATING } from '../../../../core/services/progress.service';
 import { QuestionService } from '../../../../core/services/question.service';
 import { TodayPlanService } from '../../../../core/services/today-plan.service';
+import type { Progress } from '../../../../shared/models/progress.model';
 import type { Question, QuestionCategory } from '../../../../shared/models/question.model';
 import { topicIdFromQuestion } from '../../../../shared/utils/topic-key.utils';
 import type { SelfRating } from '../../../../shared/models/self-rating.model';
@@ -30,6 +31,16 @@ export interface SessionProgressCounts {
     answered: number;
     remaining: number;
     total: number;
+}
+
+interface UndoSnapshot {
+    question: Question;
+    previousProgress: Progress | null;
+    sessionNailed: number;
+    sessionPartial: number;
+    sessionDidntKnow: number;
+    sessionBestStreak: number;
+    streak: number;
 }
 
 @Component({
@@ -81,6 +92,8 @@ export class QuizPageComponent {
     protected readonly sessionDidntKnow = signal(0);
     protected readonly sessionBestStreak = signal(0);
     private currentStreak = 0;
+
+    protected readonly undoSnapshot = signal<UndoSnapshot | null>(null);
 
     /** Today's plan has topics selected but none marked studied yet — practice still uses full catalog. */
     protected readonly planFocusHint = computed(
@@ -194,6 +207,9 @@ export class QuizPageComponent {
             if (!isInteractive && (event.key === 'Enter' || event.key === ' ')) {
                 event.preventDefault();
                 this.goToAnswer();
+            } else if (!isInteractive && event.key === 'ArrowLeft' && this.undoSnapshot()) {
+                event.preventDefault();
+                this.onUndoRating();
             }
         } else if (ph === 'answer') {
             if (!isTyping) {
@@ -221,6 +237,16 @@ export class QuizPageComponent {
         if (!q || this.phase() !== 'answer') {
             return;
         }
+        const previousProgress = this.progressService.getProgress().find((p) => p.questionId === q.id) ?? null;
+        this.undoSnapshot.set({
+            question: q,
+            previousProgress,
+            sessionNailed: this.sessionNailed(),
+            sessionPartial: this.sessionPartial(),
+            sessionDidntKnow: this.sessionDidntKnow(),
+            sessionBestStreak: this.sessionBestStreak(),
+            streak: this.currentStreak
+        });
         this.progressService.recordSelfRating(q.id, rating);
         this.activityService.bumpQuestionsAnswered(1);
         this.activityService.addCoveredTopic(topicIdFromQuestion(q));
@@ -323,6 +349,27 @@ export class QuizPageComponent {
         return target.toLocaleDateString(loc, { weekday: 'short', month: 'short', day: 'numeric' });
     }
 
+    protected onUndoRating(): void {
+        const snap = this.undoSnapshot();
+        if (!snap) {
+            return;
+        }
+        this.progressService.revertProgress(snap.question.id, snap.previousProgress);
+        this.activityService.undoQuestionsAnswered();
+        this.questionService.stepBack();
+        this.sessionNailed.set(snap.sessionNailed);
+        this.sessionPartial.set(snap.sessionPartial);
+        this.sessionDidntKnow.set(snap.sessionDidntKnow);
+        this.sessionBestStreak.set(snap.sessionBestStreak);
+        this.currentStreak = snap.streak;
+        this.sessionIndex.update((i) => i - 1);
+        this.currentQuestion.set(snap.question);
+        this.feedbackSnapshot.set(null);
+        this.feedbackCtx.set(null);
+        this.undoSnapshot.set(null);
+        this.phase.set('answer');
+    }
+
     private loadQuiz(): void {
         this.loading.set(true);
         this.loadError.set(false);
@@ -332,6 +379,7 @@ export class QuizPageComponent {
         this.phase.set('question');
         this.feedbackSnapshot.set(null);
         this.feedbackCtx.set(null);
+        this.undoSnapshot.set(null);
         this.sessionNailed.set(0);
         this.sessionPartial.set(0);
         this.sessionDidntKnow.set(0);

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -287,6 +287,8 @@
         "studiedTopicsFallbackDoneHint": "No questions from your studied topics were due for review, so this round used all of them.",
         "keyboardHintRate": "Press 1 · 2 · 3 to rate",
         "keyboardHintNext": "Press Enter for next question",
+        "undoRating": "Undo last rating",
+        "keyboardHintUndo": "← to undo",
         "summaryRatingsAria": "Session rating breakdown",
         "summaryBestStreak": "Best streak: {{count}} nailed in a row",
         "doneGotoDashboard": "Progress"

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -287,6 +287,8 @@
         "studiedTopicsFallbackDoneHint": "В изученных темах не было вопросов к повторению, поэтому в раунде использованы все вопросы по этим темам.",
         "keyboardHintRate": "Нажмите 1 · 2 · 3 для оценки",
         "keyboardHintNext": "Нажмите Enter для следующего вопроса",
+        "undoRating": "Отменить последнюю оценку",
+        "keyboardHintUndo": "← отменить",
         "summaryRatingsAria": "Итоги сессии по оценкам",
         "summaryBestStreak": "Лучшая серия: {{count}} «отлично» подряд",
         "doneGotoDashboard": "Прогресс"


### PR DESCRIPTION
## Summary

- An **Undo** button appears on the next question card whenever there is a rating to revert (not on the first question, not after the session ends)
- Pressing `←` (ArrowLeft) triggers the same undo action via the existing keyboard handler
- Undo restores the previous `Progress` entry in `ProgressService` (or removes it if the question had no prior history), decrements `ActivityService.questionsAnswered`, rewinds the `QuestionService` queue cursor, and rolls back all session counters (nailed / partial / didn't know / best streak / streak)
- The user lands back on the **answer** phase of the previous question to re-rate it

## Files changed

| File | Change |
|------|--------|
| `progress.service.ts` | `revertProgress(questionId, previousEntry)` — restores or removes a progress entry |
| `activity.service.ts` | `undoQuestionsAnswered()` — decrements today's answered count (floor 0) |
| `question.service.ts` | `stepBack()` — rewinds queue cursor so next advance re-delivers the current question |
| `quiz-page.component.ts` | `UndoSnapshot` interface, `undoSnapshot` signal, snapshot capture in `onSelfRated`, `onUndoRating` method, `←` keyboard shortcut, `undoSnapshot.set(null)` in `loadQuiz` |
| `quiz-page.component.html` | Undo button row (conditionally shown in question phase) |
| `quiz-page.component.scss` | `.quiz__undo-row` / `.quiz__undo-btn` styles |
| `en.json` / `ru.json` | `quiz.undoRating`, `quiz.keyboardHintUndo` |

## Acceptance criteria

- [x] Undo removes the last rating entry from storage
- [x] Undo is not available on the first question of a session
- [x] Undo is not available after the session ends

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)