### PR TITLE
Fix #40: Add difficulty filter to the study guide

### DIFF
--- a/e2e/study-guide.spec.ts
+++ b/e2e/study-guide.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Study guide difficulty filter', () => {
+    test('shows four difficulty chips with All active by default', async ({ page }) => {
+        await page.goto('/study');
+        const row = page.locator('.study__difficulty-row');
+        await expect(row).toBeVisible({ timeout: 10_000 });
+
+        const chips = row.locator('button');
+        await expect(chips).toHaveCount(4);
+
+        const allChip = chips.first();
+        await expect(allChip).toHaveAttribute('aria-pressed', 'true');
+        for (let i = 1; i < 4; i++) {
+            await expect(chips.nth(i)).toHaveAttribute('aria-pressed', 'false');
+        }
+    });
+
+    test('selecting a difficulty chip filters questions and marks it active', async ({ page }) => {
+        await page.goto('/study');
+        await expect(page.locator('.study__difficulty-row')).toBeVisible({ timeout: 10_000 });
+
+        const chips = page.locator('.study__difficulty-row button');
+        const beginnerChip = chips.nth(1);
+
+        await beginnerChip.click();
+        await expect(beginnerChip).toHaveAttribute('aria-pressed', 'true');
+        await expect(chips.first()).toHaveAttribute('aria-pressed', 'false');
+
+        await expect(page.locator('.study__cat')).not.toHaveCount(0);
+    });
+
+    test('clicking All restores the unfiltered guide', async ({ page }) => {
+        await page.goto('/study');
+        await expect(page.locator('.study__difficulty-row')).toBeVisible({ timeout: 10_000 });
+
+        const chips = page.locator('.study__difficulty-row button');
+        await chips.nth(1).click();
+        await chips.first().click();
+
+        await expect(chips.first()).toHaveAttribute('aria-pressed', 'true');
+        await expect(page.locator('.study__cat')).not.toHaveCount(0);
+    });
+
+    test('difficulty filter combines with the status filter query param', async ({ page }) => {
+        await page.goto('/study?filter=unstudied');
+        await expect(page.locator('.study__difficulty-row')).toBeVisible({ timeout: 10_000 });
+
+        const chips = page.locator('.study__difficulty-row button');
+        await chips.nth(2).click();
+        await expect(chips.nth(2)).toHaveAttribute('aria-pressed', 'true');
+        await expect(page.locator('.study__filter-row').first().locator('button').nth(2)).toHaveAttribute('aria-pressed', 'true');
+    });
+});

--- a/src/app/features/study/pages/study-guide-page/study-guide-page.component.html
+++ b/src/app/features/study/pages/study-guide-page/study-guide-page.component.html
@@ -32,6 +32,19 @@
             </button>
         }
     </div>
+    <div class="study__filter-row study__difficulty-row" role="group" [attr.aria-label]="'studyDifficulty.label' | translate">
+        @for (diff of difficultyFilters; track diff) {
+            <button
+                type="button"
+                class="study__filter-btn"
+                [class.study__filter-btn--active]="difficultyFilter() === diff"
+                [attr.aria-pressed]="difficultyFilter() === diff"
+                (click)="setDifficultyFilter(diff)"
+            >
+                {{ (diff === 'all' ? 'studyFilter.all' : 'difficulty.' + diff) | translate }}
+            </button>
+        }
+    </div>
 
     @if (showPlanCompleteBanner()) {
         <div

--- a/src/app/features/study/pages/study-guide-page/study-guide-page.component.scss
+++ b/src/app/features/study/pages/study-guide-page/study-guide-page.component.scss
@@ -96,6 +96,10 @@
     filter: brightness(1.06);
 }
 
+.study__difficulty-row {
+    margin-bottom: 0.85rem;
+}
+
 .study__expand-collapse-all {
     margin: 0;
     padding: 0.38rem 0.8rem;

--- a/src/app/features/study/pages/study-guide-page/study-guide-page.component.ts
+++ b/src/app/features/study/pages/study-guide-page/study-guide-page.component.ts
@@ -19,10 +19,11 @@ import { TodayPlanService } from '../../../../core/services/today-plan.service';
 import { QuestionService } from '../../../../core/services/question.service';
 import { AnswerBlocksComponent } from '../../../../shared/components/answer-blocks/answer-blocks.component';
 import { SplitQuestionCodePipe } from '../../../../shared/pipes/split-question-code.pipe';
-import type { Question } from '../../../../shared/models/question.model';
+import type { Question, QuestionDifficulty } from '../../../../shared/models/question.model';
 import { topicIdFromParts } from '../../../../shared/utils/topic-key.utils';
 import {
     buildStudyGuideSections,
+    filterStudyGuideSectionsByDifficulty,
     filterStudyGuideSectionsByTopicIds,
     filterStudyGuideSectionsExcludingTopicIds,
     filterStudyGuideSectionsWithoutPractice,
@@ -31,6 +32,8 @@ import {
 } from '../../study-guide-grouping';
 
 type StudyFilterMode = 'all' | 'studied' | 'unstudied' | 'never-studied';
+
+type StudyDifficultyFilter = 'all' | QuestionDifficulty;
 
 function parseFilterMode(v: string | null): StudyFilterMode {
     return v === 'studied' || v === 'unstudied' || v === 'never-studied' ? v : 'all';
@@ -101,6 +104,10 @@ export class StudyGuidePageComponent {
     private readonly accordionBulkNextIsCollapse = signal(false);
 
     protected readonly filterModes: readonly StudyFilterMode[] = ['all', 'studied', 'unstudied', 'never-studied'];
+
+    protected readonly difficultyFilters: readonly StudyDifficultyFilter[] = ['all', 'beginner', 'intermediate', 'advanced'];
+
+    protected readonly difficultyFilter = signal<StudyDifficultyFilter>('all');
 
     protected readonly filterMode = toSignal(
         this.route.queryParamMap.pipe(
@@ -176,6 +183,10 @@ export class StudyGuidePageComponent {
             all = filterStudyGuideSectionsWithoutPractice(all, this.practicedQuestionIds());
         } else if (mode === 'never-studied') {
             all = filterStudyGuideSectionsExcludingTopicIds(all, this.activityService.everStudiedTopicIds());
+        }
+        const diff = this.difficultyFilter();
+        if (diff !== 'all') {
+            all = filterStudyGuideSectionsByDifficulty(all, diff);
         }
         return all;
     });
@@ -377,6 +388,10 @@ export class StudyGuidePageComponent {
 
     protected dismissPlanCompleteBanner(): void {
         this.showPlanCompleteBanner.set(false);
+    }
+
+    protected setDifficultyFilter(f: StudyDifficultyFilter): void {
+        this.difficultyFilter.set(f);
     }
 
     protected setFilterMode(mode: StudyFilterMode): void {

--- a/src/app/features/study/study-guide-grouping.spec.ts
+++ b/src/app/features/study/study-guide-grouping.spec.ts
@@ -1,0 +1,74 @@
+import { buildStudyGuideSections, filterStudyGuideSectionsByDifficulty } from './study-guide-grouping';
+import type { Question } from '../../shared/models/question.model';
+
+function makeQuestion(
+    id: number,
+    category: 'javascript' | 'angular',
+    subtopic: string,
+    difficulty: 'beginner' | 'intermediate' | 'advanced'
+): Question {
+    return {
+        id,
+        question: `Q${id}`,
+        answer: '',
+        weakAnswer: '',
+        technicalAnswer: '',
+        interviewAnswer: '',
+        codeExample: '',
+        readMoreLinks: [],
+        subtopic,
+        category,
+        difficulty
+    };
+}
+
+describe('filterStudyGuideSectionsByDifficulty', () => {
+    const questions: Question[] = [
+        makeQuestion(1, 'javascript', 'closures', 'beginner'),
+        makeQuestion(2, 'javascript', 'closures', 'intermediate'),
+        makeQuestion(3, 'javascript', 'closures', 'advanced'),
+        makeQuestion(4, 'angular', 'signals', 'beginner'),
+        makeQuestion(5, 'angular', 'signals', 'advanced')
+    ];
+
+    const sections = buildStudyGuideSections(questions);
+
+    it('returns only questions matching the given difficulty', () => {
+        const result = filterStudyGuideSectionsByDifficulty(sections, 'beginner');
+        expect(result.length).toBe(2);
+        for (const cat of result) {
+            for (const sub of cat.subtopics) {
+                expect(sub.questions.every((q) => q.difficulty === 'beginner')).toBe(true);
+            }
+        }
+    });
+
+    it('drops subtopics that have no questions for the given difficulty', () => {
+        const result = filterStudyGuideSectionsByDifficulty(sections, 'intermediate');
+        expect(result.length).toBe(1);
+        expect(result[0].category).toBe('javascript');
+        expect(result[0].subtopics[0].questions).toHaveLength(1);
+        expect(result[0].subtopics[0].questions[0].id).toBe(2);
+    });
+
+    it('drops categories that have no matching questions', () => {
+        const jsOnly: Question[] = [makeQuestion(1, 'javascript', 'closures', 'advanced')];
+        const jsSections = buildStudyGuideSections(jsOnly);
+        const result = filterStudyGuideSectionsByDifficulty(jsSections, 'beginner');
+        expect(result).toHaveLength(0);
+    });
+
+    it('returns all matching questions across multiple subtopics', () => {
+        const multi: Question[] = [
+            makeQuestion(1, 'javascript', 'closures', 'advanced'),
+            makeQuestion(2, 'javascript', 'promises', 'advanced'),
+            makeQuestion(3, 'javascript', 'promises', 'beginner')
+        ];
+        const multiSections = buildStudyGuideSections(multi);
+        const result = filterStudyGuideSectionsByDifficulty(multiSections, 'advanced');
+        expect(result).toHaveLength(1);
+        const subs = result[0].subtopics;
+        expect(subs).toHaveLength(2);
+        expect(subs.every((s) => s.questions.every((q) => q.difficulty === 'advanced'))).toBe(true);
+    });
+});

--- a/src/app/features/study/study-guide-grouping.ts
+++ b/src/app/features/study/study-guide-grouping.ts
@@ -1,4 +1,4 @@
-import type { Question, QuestionCategory } from '../../shared/models/question.model';
+import type { Question, QuestionCategory, QuestionDifficulty } from '../../shared/models/question.model';
 import { topicIdFromParts } from '../../shared/utils/topic-key.utils';
 
 const CATEGORY_ORDER: QuestionCategory[] = ['javascript', 'angular', 'rxjs', 'custom'];
@@ -90,6 +90,27 @@ export function filterStudyGuideSectionsWithoutPractice(
         const subs = cat.subtopics.filter((sub) =>
             sub.questions.every((q) => !practicedQuestionIds.has(q.id))
         );
+        if (subs.length > 0) {
+            out.push({ ...cat, subtopics: subs });
+        }
+    }
+    return out;
+}
+
+/** Keep only questions matching `difficulty` within each subtopic. Drops empty subtopics/categories. */
+export function filterStudyGuideSectionsByDifficulty(
+    sections: StudyCategorySection[],
+    difficulty: QuestionDifficulty
+): StudyCategorySection[] {
+    const out: StudyCategorySection[] = [];
+    for (const cat of sections) {
+        const subs: StudySubtopicSection[] = [];
+        for (const sub of cat.subtopics) {
+            const questions = sub.questions.filter((q) => q.difficulty === difficulty);
+            if (questions.length > 0) {
+                subs.push({ ...sub, questions });
+            }
+        }
         if (subs.length > 0) {
             out.push({ ...cat, subtopics: subs });
         }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -149,6 +149,9 @@
         "filteredRetryBanner": "Showing topics you had trouble with recently.",
         "filteredRetryClear": "Show all topics"
     },
+    "studyDifficulty": {
+        "label": "Filter by difficulty"
+    },
     "studyFilter": {
         "label": "Filter topics",
         "all": "All",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -149,6 +149,9 @@
         "filteredRetryBanner": "Показаны темы, с которыми были затруднения недавно.",
         "filteredRetryClear": "Показать все темы"
     },
+    "studyDifficulty": {
+        "label": "Фильтр по сложности"
+    },
     "studyFilter": {
         "label": "Фильтр тем",
         "all": "Все",


### PR DESCRIPTION
All changes look correct. Here is the pull request description:

## Summary

- Add `filterStudyGuideSectionsByDifficulty` utility to `study-guide-grouping.ts` that filters questions within subtopics by difficulty level, dropping empty subtopics and categories
- Add a session-scoped `difficultyFilter` signal and `setDifficultyFilter` method to `StudyGuidePageComponent`; apply the filter last in the `sections` computed so it stacks with all existing filters (`?today=1`, `?topics=`, `?filter=`)
- Add a row of four chip buttons (All / Beginner / Intermediate / Advanced) to the study guide toolbar, reusing the existing `.study__filter-btn` style

## Files changed

| File | Change |
|------|--------|
| `src/app/features/study/study-guide-grouping.ts` | Add `filterStudyGuideSectionsByDifficulty` function; import `QuestionDifficulty` |
| `src/app/features/study/pages/study-guide-page/study-guide-page.component.ts` | Add `StudyDifficultyFilter` type, `difficultyFilters` constant, `difficultyFilter` signal, `setDifficultyFilter` method; apply difficulty filter in `sections` computed |
| `src/app/features/study/pages/study-guide-page/study-guide-page.component.html` | Add difficulty filter chip row below the toolbar |
| `src/app/features/study/pages/study-guide-page/study-guide-page.component.scss` | Add `.study__difficulty-row` bottom margin |
| `src/assets/i18n/en.json` | Add `studyDifficulty.label` translation key |
| `src/assets/i18n/ru.json` | Add `studyDifficulty.label` translation key (Russian) |
| `src/app/features/study/study-guide-grouping.spec.ts` | Unit tests for `filterStudyGuideSectionsByDifficulty` |
| `e2e/study-guide.spec.ts` | E2E tests for the difficulty chip UI and filter behaviour |

## Acceptance criteria

- [x] Difficulty filter chips (All / Beginner / Intermediate / Advanced) appear on the study guide page
- [x] Selecting a chip filters all categories simultaneously to show only questions of that difficulty
- [x] Filter is session-scoped (signal, not localStorage or URL param)
- [x] Difficulty filter can be combined with `?today=1`, `?topics=`, and `?filter=` params

Closes #40

🤖 Generated with [mouse-fixes](https://github.com/ZhannaM85/mouse-fixes)