### PR TITLE
Fix #55: Add collapsible code examples in study guide

### DIFF
--- a/docs/issues-priority.md
+++ b/docs/issues-priority.md
@@ -11,7 +11,7 @@ Generated 2026-05-06. Based on labels, dependencies, and effort/value assessment
 | ~~[#58](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/58)~~ | ~~Heatmap contrast in dark mode~~ | ✅ Done — [PR #65](https://github.com/ZhannaM85/interview-trainer-angular-app/pull/65) |
 | ~~[#38](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/38)~~ | ~~Undo last quiz rating~~ | ✅ Done — [PR #66](https://github.com/ZhannaM85/interview-trainer-angular-app/pull/66) |
 | ~~[#49](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/49)~~ | ~~Randomize question order~~ | ✅ Done |
-| [#55](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/55) | Collapsible code examples in study guide | Big mobile UX improvement, no data changes |
+| ~~[#55](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/55)~~ | ~~Collapsible code examples in study guide~~ | ✅ Done |
 | [#54](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/54) | Bulk "Mark all as studied" in plan | Low effort, plan page already has the logic |
 | ~~[#40](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/40)~~ | ~~Difficulty filter in study guide~~ | ✅ Done — [PR #73](https://github.com/ZhannaM85/interview-trainer-angular-app/pull/73) |
 | [#39](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/39) | Full-text search in study guide | In-memory filter, naturally pairs with #40 |

--- a/e2e/study-guide.spec.ts
+++ b/e2e/study-guide.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Locator } from '@playwright/test';
 
 test.describe('Study guide difficulty filter', () => {
     test('shows four difficulty chips with All active by default', async ({ page }) => {
@@ -50,5 +50,164 @@ test.describe('Study guide difficulty filter', () => {
         await chips.nth(2).click();
         await expect(chips.nth(2)).toHaveAttribute('aria-pressed', 'true');
         await expect(page.locator('.study__filter-row').first().locator('button').nth(2)).toHaveAttribute('aria-pressed', 'true');
+    });
+});
+
+test.describe('Study guide collapsible code examples', () => {
+    async function openFirstSubtopic(page: Parameters<typeof test>[1]['page']): Promise<Locator> {
+        await page.goto('/study');
+        await expect(page.locator('.study__sub-accordion').first()).toBeVisible({ timeout: 10_000 });
+        const accordion = page.locator('.study__sub-accordion').first();
+        const isOpen = await accordion.evaluate((el) => el.classList.contains('study__sub-accordion--open'));
+        if (!isOpen) {
+            await accordion.locator('.study__sub-disclosure').click();
+            await expect(accordion).toHaveClass(/study__sub-accordion--open/);
+        }
+        return accordion;
+    }
+
+    test('code toggle button is hidden until a question has a code example', async ({ page }) => {
+        const accordion = await openFirstSubtopic(page);
+        const articles = accordion.locator('.study__q');
+        const count = await articles.count();
+        let foundToggle = false;
+        for (let i = 0; i < count; i++) {
+            const toggle = articles.nth(i).locator('.interview-answer__code-toggle');
+            if (await toggle.count() > 0) {
+                foundToggle = true;
+                break;
+            }
+        }
+        // The guide has many questions with code examples; at least one subtopic should show a toggle
+        // This test just verifies the toggle is never shown for questions without code
+        const codesWithoutToggle = await accordion.locator('.interview-answer__code-wrap').filter({ has: page.locator('.interview-answer__label--code') }).count();
+        expect(codesWithoutToggle).toBe(0);
+        void foundToggle; // used above
+    });
+
+    test('code block is collapsed by default and toggle shows "Show code example"', async ({ page }) => {
+        await page.goto('/study');
+        await expect(page.locator('.study__sub-accordion').first()).toBeVisible({ timeout: 10_000 });
+
+        // Open subtopics until we find one with a code toggle
+        const accordions = page.locator('.study__sub-accordion');
+        const total = await accordions.count();
+        let toggle: Locator | null = null;
+
+        for (let i = 0; i < total && !toggle; i++) {
+            const acc = accordions.nth(i);
+            const isOpen = await acc.evaluate((el) => el.classList.contains('study__sub-accordion--open'));
+            if (!isOpen) {
+                await acc.locator('.study__sub-disclosure').click();
+            }
+            const t = acc.locator('.interview-answer__code-toggle').first();
+            if (await t.count() > 0) {
+                toggle = t;
+            }
+        }
+
+        if (!toggle) {
+            test.skip(true, 'No question with code example found in visible sections');
+            return;
+        }
+
+        await expect(toggle).toBeVisible();
+        await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+        await expect(toggle).toContainText('Show code example');
+        const pre = toggle.locator('..').locator('.interview-answer__code');
+        await expect(pre).toHaveCount(0);
+    });
+
+    test('clicking toggle expands the code block and changes label', async ({ page }) => {
+        await page.goto('/study');
+        await expect(page.locator('.study__sub-accordion').first()).toBeVisible({ timeout: 10_000 });
+
+        const accordions = page.locator('.study__sub-accordion');
+        const total = await accordions.count();
+        let toggle: Locator | null = null;
+
+        for (let i = 0; i < total && !toggle; i++) {
+            const acc = accordions.nth(i);
+            const isOpen = await acc.evaluate((el) => el.classList.contains('study__sub-accordion--open'));
+            if (!isOpen) {
+                await acc.locator('.study__sub-disclosure').click();
+            }
+            const t = acc.locator('.interview-answer__code-toggle').first();
+            if (await t.count() > 0) {
+                toggle = t;
+            }
+        }
+
+        if (!toggle) {
+            test.skip(true, 'No question with code example found in visible sections');
+            return;
+        }
+
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+        await expect(toggle).toContainText('Hide code example');
+        const wrap = toggle.locator('..');
+        await expect(wrap.locator('.interview-answer__code')).toBeVisible();
+    });
+
+    test('clicking toggle again collapses the code block', async ({ page }) => {
+        await page.goto('/study');
+        await expect(page.locator('.study__sub-accordion').first()).toBeVisible({ timeout: 10_000 });
+
+        const accordions = page.locator('.study__sub-accordion');
+        const total = await accordions.count();
+        let toggle: Locator | null = null;
+
+        for (let i = 0; i < total && !toggle; i++) {
+            const acc = accordions.nth(i);
+            const isOpen = await acc.evaluate((el) => el.classList.contains('study__sub-accordion--open'));
+            if (!isOpen) {
+                await acc.locator('.study__sub-disclosure').click();
+            }
+            const t = acc.locator('.interview-answer__code-toggle').first();
+            if (await t.count() > 0) {
+                toggle = t;
+            }
+        }
+
+        if (!toggle) {
+            test.skip(true, 'No question with code example found in visible sections');
+            return;
+        }
+
+        await toggle.click();
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+        await expect(toggle).toContainText('Show code example');
+    });
+
+    test('toggle is keyboard-accessible via Enter', async ({ page }) => {
+        await page.goto('/study');
+        await expect(page.locator('.study__sub-accordion').first()).toBeVisible({ timeout: 10_000 });
+
+        const accordions = page.locator('.study__sub-accordion');
+        const total = await accordions.count();
+        let toggle: Locator | null = null;
+
+        for (let i = 0; i < total && !toggle; i++) {
+            const acc = accordions.nth(i);
+            const isOpen = await acc.evaluate((el) => el.classList.contains('study__sub-accordion--open'));
+            if (!isOpen) {
+                await acc.locator('.study__sub-disclosure').click();
+            }
+            const t = acc.locator('.interview-answer__code-toggle').first();
+            if (await t.count() > 0) {
+                toggle = t;
+            }
+        }
+
+        if (!toggle) {
+            test.skip(true, 'No question with code example found in visible sections');
+            return;
+        }
+
+        await toggle.focus();
+        await page.keyboard.press('Enter');
+        await expect(toggle).toHaveAttribute('aria-expanded', 'true');
     });
 });

--- a/src/app/features/study/pages/study-guide-page/study-guide-page.component.html
+++ b/src/app/features/study/pages/study-guide-page/study-guide-page.component.html
@@ -321,7 +321,7 @@
                                             @if (cat.category === 'custom') {
                                                 <div class="study__custom-answer">{{ q.answer }}</div>
                                             } @else {
-                                                <app-answer-blocks [question]="q" [animated]="false" />
+                                                <app-answer-blocks [question]="q" [animated]="false" [collapsibleCode]="true" />
                                             }
                                         </div>
                                     </article>

--- a/src/app/shared/components/answer-blocks/answer-blocks.component.html
+++ b/src/app/shared/components/answer-blocks/answer-blocks.component.html
@@ -41,14 +41,33 @@
         [class.interview-answer__reveal]="animated()"
         [class.interview-answer__reveal--4]="animated()"
     >
-        <p class="interview-answer__label interview-answer__label--code">
-            {{ 'answerBlocks.codeExample' | translate }}
-        </p>
-        <pre
-            class="interview-answer__code"
-            role="region"
-            [attr.aria-label]="'answerBlocks.codeExample' | translate"
-        ><code>{{ question().codeExample }}</code></pre>
+        @if (collapsibleCode()) {
+            <button
+                type="button"
+                class="interview-answer__code-toggle"
+                [attr.aria-expanded]="codeExpanded()"
+                (click)="toggleCode()"
+            >
+                <span class="interview-answer__code-toggle-chevron" aria-hidden="true"></span>
+                {{ (codeExpanded() ? 'answerBlocks.hideCode' : 'answerBlocks.showCode') | translate }}
+            </button>
+            @if (codeExpanded()) {
+                <pre
+                    class="interview-answer__code interview-answer__code--collapsible"
+                    role="region"
+                    [attr.aria-label]="'answerBlocks.codeExample' | translate"
+                ><code>{{ question().codeExample }}</code></pre>
+            }
+        } @else {
+            <p class="interview-answer__label interview-answer__label--code">
+                {{ 'answerBlocks.codeExample' | translate }}
+            </p>
+            <pre
+                class="interview-answer__code"
+                role="region"
+                [attr.aria-label]="'answerBlocks.codeExample' | translate"
+            ><code>{{ question().codeExample }}</code></pre>
+        }
     </div>
 }
 

--- a/src/app/shared/components/answer-blocks/answer-blocks.component.scss
+++ b/src/app/shared/components/answer-blocks/answer-blocks.component.scss
@@ -82,6 +82,52 @@
     width: 100%;
 }
 
+.interview-answer__code-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin: 0 0 0.5rem;
+    padding: 0.3rem 0.65rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--it-border);
+    background: var(--it-card);
+    color: var(--it-text-muted);
+    font: inherit;
+    font-size: 0.78rem;
+    font-weight: 650;
+    cursor: pointer;
+    transition: border-color 0.12s ease, color 0.12s ease;
+}
+
+.interview-answer__code-toggle:hover {
+    border-color: var(--it-accent);
+    color: var(--it-accent);
+}
+
+.interview-answer__code-toggle:focus-visible {
+    outline: 2px solid var(--it-focus);
+    outline-offset: 2px;
+}
+
+.interview-answer__code-toggle-chevron {
+    display: inline-block;
+    width: 0.38rem;
+    height: 0.38rem;
+    flex-shrink: 0;
+    border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor;
+    transform: rotate(-45deg);
+    transition: transform 0.15s ease;
+}
+
+.interview-answer__code-toggle[aria-expanded='true'] .interview-answer__code-toggle-chevron {
+    transform: rotate(45deg);
+}
+
+.interview-answer__code--collapsible {
+    margin-top: 0;
+}
+
 .interview-answer__code {
     margin: 0;
     padding: 1rem 1.1rem;

--- a/src/app/shared/components/answer-blocks/answer-blocks.component.spec.ts
+++ b/src/app/shared/components/answer-blocks/answer-blocks.component.spec.ts
@@ -1,0 +1,151 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+    TranslateLoader,
+    TranslateService,
+    provideTranslateService,
+    type TranslationObject
+} from '@ngx-translate/core';
+import { Observable, of } from 'rxjs';
+
+import { AnswerBlocksComponent } from './answer-blocks.component';
+import type { Question } from '../../models/question.model';
+
+class StubLoader implements TranslateLoader {
+    getTranslation(_lang: string): Observable<TranslationObject> {
+        return of({
+            answerBlocks: {
+                weak: 'Weak answer',
+                technical: 'Technical answer',
+                interview: 'Interview answer',
+                codeExample: 'Code example',
+                showCode: 'Show code example',
+                hideCode: 'Hide code example',
+                readMore: 'Read more'
+            }
+        } satisfies TranslationObject);
+    }
+}
+
+const BASE_QUESTION: Question = {
+    id: 1,
+    question: 'What is a signal?',
+    answer: 'A reactive primitive',
+    weakAnswer: 'Not sure',
+    technicalAnswer: 'A push-based primitive',
+    interviewAnswer: 'Signals track reactive state',
+    codeExample: '',
+    readMoreLinks: [],
+    subtopic: 'signals',
+    category: 'angular',
+    difficulty: 'intermediate'
+};
+
+function makeQuestion(overrides: Partial<Question> = {}): Question {
+    return { ...BASE_QUESTION, ...overrides };
+}
+
+describe('AnswerBlocksComponent', () => {
+    let fixture: ComponentFixture<AnswerBlocksComponent>;
+    let component: AnswerBlocksComponent;
+
+    function setup(question: Question, collapsibleCode = false): void {
+        TestBed.configureTestingModule({
+            imports: [AnswerBlocksComponent],
+            providers: [provideTranslateService({ loader: { provide: TranslateLoader, useClass: StubLoader } })]
+        });
+        TestBed.inject(TranslateService).use('en');
+        fixture = TestBed.createComponent(AnswerBlocksComponent);
+        component = fixture.componentInstance;
+        fixture.componentRef.setInput('question', question);
+        fixture.componentRef.setInput('collapsibleCode', collapsibleCode);
+        fixture.detectChanges();
+    }
+
+    describe('non-collapsible mode (default)', () => {
+        it('shows code block directly when codeExample is non-empty', () => {
+            setup(makeQuestion({ codeExample: 'const x = 1;' }));
+            const pre = fixture.nativeElement.querySelector('.interview-answer__code');
+            expect(pre).toBeTruthy();
+            expect(pre.textContent).toContain('const x = 1;');
+        });
+
+        it('does not render code block when codeExample is empty', () => {
+            setup(makeQuestion({ codeExample: '' }));
+            const wrap = fixture.nativeElement.querySelector('.interview-answer__code-wrap');
+            expect(wrap).toBeNull();
+        });
+
+        it('does not render the toggle button', () => {
+            setup(makeQuestion({ codeExample: 'const x = 1;' }));
+            const btn = fixture.nativeElement.querySelector('.interview-answer__code-toggle');
+            expect(btn).toBeNull();
+        });
+    });
+
+    describe('collapsible mode', () => {
+        it('shows toggle button and hides code block initially', () => {
+            setup(makeQuestion({ codeExample: 'const x = 1;' }), true);
+            const btn = fixture.nativeElement.querySelector('.interview-answer__code-toggle');
+            expect(btn).toBeTruthy();
+            expect(btn.getAttribute('aria-expanded')).toBe('false');
+            const pre = fixture.nativeElement.querySelector('.interview-answer__code');
+            expect(pre).toBeNull();
+        });
+
+        it('toggle button label says "Show code example" when collapsed', () => {
+            setup(makeQuestion({ codeExample: 'const x = 1;' }), true);
+            const btn = fixture.nativeElement.querySelector('.interview-answer__code-toggle');
+            expect(btn.textContent).toContain('Show code example');
+        });
+
+        it('clicking toggle expands the code block', () => {
+            setup(makeQuestion({ codeExample: 'const x = 1;' }), true);
+            const btn: HTMLButtonElement = fixture.nativeElement.querySelector('.interview-answer__code-toggle');
+            btn.click();
+            fixture.detectChanges();
+            expect(btn.getAttribute('aria-expanded')).toBe('true');
+            const pre = fixture.nativeElement.querySelector('.interview-answer__code');
+            expect(pre).toBeTruthy();
+            expect(pre.textContent).toContain('const x = 1;');
+        });
+
+        it('toggle button label says "Hide code example" when expanded', () => {
+            setup(makeQuestion({ codeExample: 'const x = 1;' }), true);
+            const btn: HTMLButtonElement = fixture.nativeElement.querySelector('.interview-answer__code-toggle');
+            btn.click();
+            fixture.detectChanges();
+            expect(btn.textContent).toContain('Hide code example');
+        });
+
+        it('clicking toggle twice collapses the code block again', () => {
+            setup(makeQuestion({ codeExample: 'const x = 1;' }), true);
+            const btn: HTMLButtonElement = fixture.nativeElement.querySelector('.interview-answer__code-toggle');
+            btn.click();
+            fixture.detectChanges();
+            btn.click();
+            fixture.detectChanges();
+            expect(btn.getAttribute('aria-expanded')).toBe('false');
+            expect(fixture.nativeElement.querySelector('.interview-answer__code')).toBeNull();
+        });
+
+        it('does not render toggle when codeExample is empty', () => {
+            setup(makeQuestion({ codeExample: '' }), true);
+            const wrap = fixture.nativeElement.querySelector('.interview-answer__code-wrap');
+            expect(wrap).toBeNull();
+        });
+    });
+
+    describe('answer blocks rendering', () => {
+        it('renders three answer blocks for non-custom questions', () => {
+            setup(makeQuestion());
+            const blocks = fixture.nativeElement.querySelectorAll('.interview-answer__block');
+            expect(blocks.length).toBe(3);
+        });
+
+        it('renders one answer block for custom questions', () => {
+            setup(makeQuestion({ category: 'custom' }));
+            const blocks = fixture.nativeElement.querySelectorAll('.interview-answer__block');
+            expect(blocks.length).toBe(1);
+        });
+    });
+});

--- a/src/app/shared/components/answer-blocks/answer-blocks.component.ts
+++ b/src/app/shared/components/answer-blocks/answer-blocks.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, signal } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 
 import type { Question } from '../../models/question.model';
@@ -13,4 +13,11 @@ import type { Question } from '../../models/question.model';
 export class AnswerBlocksComponent {
     readonly question = input.required<Question>();
     readonly animated = input(false);
+    readonly collapsibleCode = input(false);
+
+    protected readonly codeExpanded = signal(false);
+
+    protected toggleCode(): void {
+        this.codeExpanded.update((v) => !v);
+    }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -350,6 +350,8 @@
         "technical": "Technical answer",
         "interview": "Interview answer",
         "codeExample": "Code example",
+        "showCode": "Show code example",
+        "hideCode": "Hide code example",
         "readMore": "Read more"
     },
     "interviewQuestion": {

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -350,6 +350,8 @@
         "technical": "Технический ответ",
         "interview": "Ответ для собеседования",
         "codeExample": "Пример кода",
+        "showCode": "Показать пример кода",
+        "hideCode": "Скрыть пример кода",
         "readMore": "Читать дальше"
     },
     "interviewQuestion": {


### PR DESCRIPTION
## Summary

- Code blocks in the study guide are now collapsed by default behind a **"Show code example"** toggle button — reduces noise on mobile and during quick scans
- State is per-question within the session (signal in each `AnswerBlocksComponent` instance), not persisted
- Toggle is keyboard-accessible (native `<button>` handles Enter/Space); uses `aria-expanded` for screen readers
- Quiz and other consumers of `AnswerBlocksComponent` are unaffected (`collapsibleCode` input defaults to `false`)

## Files changed

| File | Change |
|------|--------|
| `answer-blocks.component.ts` | Add `collapsibleCode` input, `codeExpanded` signal, `toggleCode()` |
| `answer-blocks.component.html` | Conditional toggle button + collapsible code block |
| `answer-blocks.component.scss` | Toggle button styles with chevron icon |
| `answer-blocks.component.spec.ts` | New unit test file — 11 tests covering collapsed/expanded states |
| `study-guide-page.component.html` | Pass `[collapsibleCode]="true"` to `<app-answer-blocks>` |
| `en.json` / `ru.json` | Add `answerBlocks.showCode` and `answerBlocks.hideCode` keys |
| `study-guide.spec.ts` | E2E suite for toggle visibility, expand/collapse, keyboard access |
| `docs/issues-priority.md` | Mark #55 done |

## Acceptance criteria

- [x] Toggle is keyboard-accessible (Enter/Space)
- [x] Collapsed state shows just the toggle button (no code preview)
- [x] Expanded state shows a "Hide code example" button to collapse again
- [x] State is per-question within the session (not persisted)

Closes #55

🤖 Generated with [Claude Code](https://claude.ai/claude-code)