### PR TITLE
Fix #54: Add bulk 'Mark all as studied' action in the plan

### DIFF
--- a/docs/issues-priority.md
+++ b/docs/issues-priority.md
@@ -12,7 +12,7 @@ Generated 2026-05-06. Based on labels, dependencies, and effort/value assessment
 | ~~[#38](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/38)~~ | ~~Undo last quiz rating~~ | ✅ Done — [PR #66](https://github.com/ZhannaM85/interview-trainer-angular-app/pull/66) |
 | ~~[#49](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/49)~~ | ~~Randomize question order~~ | ✅ Done |
 | ~~[#55](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/55)~~ | ~~Collapsible code examples in study guide~~ | ✅ Done |
-| [#54](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/54) | Bulk "Mark all as studied" in plan | Low effort, plan page already has the logic |
+| ~~[#54](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/54)~~ | ~~Bulk "Mark all as studied" in plan~~ | ✅ Done |
 | ~~[#40](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/40)~~ | ~~Difficulty filter in study guide~~ | ✅ Done — [PR #73](https://github.com/ZhannaM85/interview-trainer-angular-app/pull/73) |
 | [#39](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/39) | Full-text search in study guide | In-memory filter, naturally pairs with #40 |
 

--- a/src/app/features/plan/pages/plan-page/plan-page.component.html
+++ b/src/app/features/plan/pages/plan-page/plan-page.component.html
@@ -15,7 +15,33 @@
             <h2 id="plan-summary-heading" class="plan__summary-heading">{{ 'plan.summaryHeading' | translate }}</h2>
             <div class="plan__summary-cols">
                 <div class="plan__summary-col">
-                    <h3 class="plan__summary-sub">{{ 'plan.toStudy' | translate }}</h3>
+                    <div class="plan__summary-sub-row">
+                        <h3 class="plan__summary-sub">{{ 'plan.toStudy' | translate }}</h3>
+                        @if (topicsRemainingToStudyJs().length > 0) {
+                            @if (confirmMarkAllStudied() === 'global') {
+                                <span class="plan__remove-all-confirm">
+                                    {{ 'plan.markAllStudiedConfirm' | translate }}
+                                    <button
+                                        type="button"
+                                        class="plan__remove-all plan__remove-all--danger"
+                                        (click)="confirmMarkAllStudiedTopics()"
+                                    >{{ 'plan.markAllStudiedYes' | translate }}</button>
+                                    <button
+                                        type="button"
+                                        class="plan__remove-all"
+                                        (click)="cancelMarkAllStudied()"
+                                    >{{ 'plan.removeAllNo' | translate }}</button>
+                                </span>
+                            } @else {
+                                <button
+                                    type="button"
+                                    class="plan__remove-all"
+                                    [attr.aria-label]="'plan.markAllStudiedAria' | translate"
+                                    (click)="requestMarkAllStudied('global')"
+                                >{{ 'plan.markAllStudied' | translate }}</button>
+                            }
+                        }
+                    </div>
                     @if (topicsRemainingToStudyJs().length === 0) {
                         <p class="plan__summary-empty">{{ 'plan.toStudyEmpty' | translate }}</p>
                     } @else {
@@ -128,9 +154,35 @@
 
         @for (cat of sections(); track cat.anchorId) {
             <section class="plan__cat" [attr.aria-labelledby]="cat.anchorId + '__heading'">
-                <h3 class="plan__cat-heading" [attr.id]="cat.anchorId + '__heading'">
-                    {{ ('study.category.' + cat.category) | translate }}
-                </h3>
+                <div class="plan__cat-heading-row">
+                    <h3 class="plan__cat-heading" [attr.id]="cat.anchorId + '__heading'">
+                        {{ ('study.category.' + cat.category) | translate }}
+                    </h3>
+                    @if (categorySelectedUnstudiedCount(cat) > 0) {
+                        @if (confirmMarkAllStudied() === cat.anchorId) {
+                            <span class="plan__remove-all-confirm">
+                                {{ 'plan.markAllStudiedConfirm' | translate }}
+                                <button
+                                    type="button"
+                                    class="plan__remove-all plan__remove-all--danger"
+                                    (click)="confirmMarkAllStudiedTopics()"
+                                >{{ 'plan.markAllStudiedYes' | translate }}</button>
+                                <button
+                                    type="button"
+                                    class="plan__remove-all"
+                                    (click)="cancelMarkAllStudied()"
+                                >{{ 'plan.removeAllNo' | translate }}</button>
+                            </span>
+                        } @else {
+                            <button
+                                type="button"
+                                class="plan__remove-all"
+                                [attr.aria-label]="'plan.markAllStudiedCatAria' | translate: { cat: ('study.category.' + cat.category | translate) }"
+                                (click)="requestMarkAllStudied(cat.anchorId)"
+                            >{{ 'plan.markAllStudied' | translate }}</button>
+                        }
+                    }
+                </div>
                 <ul class="plan__topic-list">
                     @for (sub of cat.subtopics; track sub.anchorId) {
                         <li class="plan__topic-item">

--- a/src/app/features/plan/pages/plan-page/plan-page.component.scss
+++ b/src/app/features/plan/pages/plan-page/plan-page.component.scss
@@ -282,8 +282,16 @@
     background: var(--it-card);
 }
 
+.plan__cat-heading-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.65rem;
+}
+
 .plan__cat-heading {
-    margin: 0 0 0.65rem;
+    margin: 0;
     font-size: 1rem;
     font-weight: 800;
 }

--- a/src/app/features/plan/pages/plan-page/plan-page.component.spec.ts
+++ b/src/app/features/plan/pages/plan-page/plan-page.component.spec.ts
@@ -1,0 +1,114 @@
+import { provideHttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { TranslateLoader, TranslateService, provideTranslateService, type TranslationObject } from '@ngx-translate/core';
+import { Observable, of } from 'rxjs';
+
+import { PlanPageComponent } from './plan-page.component';
+import { TodayPlanService } from '../../../../core/services/today-plan.service';
+
+class StubLoader implements TranslateLoader {
+    getTranslation(): Observable<TranslationObject> {
+        return of({ plan: {}, study: { category: {} } });
+    }
+}
+
+async function setup() {
+    localStorage.clear();
+    await TestBed.configureTestingModule({
+        imports: [PlanPageComponent],
+        providers: [
+            provideHttpClient(),
+            provideRouter([]),
+            ...provideTranslateService({ loader: { provide: TranslateLoader, useClass: StubLoader } })
+        ]
+    }).compileComponents();
+    TestBed.inject(TranslateService).use('en');
+    const fixture = TestBed.createComponent(PlanPageComponent);
+    const component = fixture.componentInstance as unknown as {
+        confirmMarkAllStudied: ReturnType<typeof import('@angular/core').signal<string | null>>;
+        requestMarkAllStudied(key: string): void;
+        confirmMarkAllStudiedTopics(): void;
+        cancelMarkAllStudied(): void;
+        topicsRemainingToStudyJs: () => string[];
+    };
+    fixture.detectChanges();
+    return { fixture, component, plan: TestBed.inject(TodayPlanService) };
+}
+
+describe('PlanPageComponent — bulk mark all as studied', () => {
+    afterEach(() => {
+        TestBed.resetTestingModule();
+        localStorage.clear();
+    });
+
+    it('confirmMarkAllStudied starts as null', async () => {
+        const { component } = await setup();
+        expect(component.confirmMarkAllStudied()).toBeNull();
+    });
+
+    it('requestMarkAllStudied sets the pending key', async () => {
+        const { component } = await setup();
+        component.requestMarkAllStudied('global');
+        expect(component.confirmMarkAllStudied()).toBe('global');
+    });
+
+    it('cancelMarkAllStudied resets to null', async () => {
+        const { component } = await setup();
+        component.requestMarkAllStudied('global');
+        component.cancelMarkAllStudied();
+        expect(component.confirmMarkAllStudied()).toBeNull();
+    });
+
+    it('confirmMarkAllStudiedTopics resets signal after confirming', async () => {
+        const { component } = await setup();
+        component.requestMarkAllStudied('global');
+        component.confirmMarkAllStudiedTopics();
+        expect(component.confirmMarkAllStudied()).toBeNull();
+    });
+
+    it('confirmMarkAllStudiedTopics marks all remaining JS topics as studied', async () => {
+        const { component, plan } = await setup();
+
+        // Select two topics directly via TodayPlanService
+        plan.toggleTopicSelected('javascript:closures');
+        plan.toggleTopicSelected('angular:signals');
+        expect(plan.topicsRemainingToStudy().length).toBe(2);
+
+        component.requestMarkAllStudied('global');
+        component.confirmMarkAllStudiedTopics();
+
+        expect(plan.isStudied('javascript:closures')).toBe(true);
+        expect(plan.isStudied('angular:signals')).toBe(true);
+        expect(plan.topicsRemainingToStudy().length).toBe(0);
+    });
+
+    it('only marks selected topics — unselected topics are left untouched', async () => {
+        const { component, plan } = await setup();
+
+        plan.toggleTopicSelected('javascript:closures');
+        // angular:signals not selected
+
+        component.requestMarkAllStudied('global');
+        component.confirmMarkAllStudiedTopics();
+
+        expect(plan.isStudied('javascript:closures')).toBe(true);
+        expect(plan.isStudied('angular:signals')).toBe(false);
+    });
+
+    it('does nothing when confirmMarkAllStudied is null', async () => {
+        const { component, plan } = await setup();
+        plan.toggleTopicSelected('javascript:closures');
+
+        // Do NOT call requestMarkAllStudied
+        component.confirmMarkAllStudiedTopics();
+
+        expect(plan.isStudied('javascript:closures')).toBe(false);
+    });
+
+    it('requestMarkAllStudied can hold a category key for per-category confirmation', async () => {
+        const { component } = await setup();
+        component.requestMarkAllStudied('javascript__heading');
+        expect(component.confirmMarkAllStudied()).toBe('javascript__heading');
+    });
+});

--- a/src/app/features/plan/pages/plan-page/plan-page.component.ts
+++ b/src/app/features/plan/pages/plan-page/plan-page.component.ts
@@ -149,6 +149,50 @@ export class PlanPageComponent {
         this.confirmRemoveAll.set(false);
     }
 
+    /**
+     * Holds `'global'` or a category `anchorId` while waiting for confirmation.
+     * Only one pending confirmation at a time.
+     */
+    protected readonly confirmMarkAllStudied = signal<string | null>(null);
+
+    protected categorySelectedUnstudiedCount(cat: StudyCategorySection): number {
+        return cat.subtopics.filter((sub) => {
+            const id = this.topicId(cat, sub);
+            return this.todayPlan.isSelected(id) && !this.todayPlan.isStudied(id);
+        }).length;
+    }
+
+    protected requestMarkAllStudied(key: string): void {
+        this.confirmMarkAllStudied.set(key);
+    }
+
+    protected confirmMarkAllStudiedTopics(): void {
+        const key = this.confirmMarkAllStudied();
+        if (!key) return;
+
+        if (key === 'global') {
+            for (const id of [...this.topicsRemainingToStudyJs()]) {
+                this.todayPlan.markStudied(id);
+            }
+        } else {
+            const cat = this.sections().find((c) => c.anchorId === key);
+            if (cat) {
+                for (const sub of cat.subtopics) {
+                    const id = this.topicId(cat, sub);
+                    if (this.todayPlan.isSelected(id) && !this.todayPlan.isStudied(id)) {
+                        this.todayPlan.markStudied(id);
+                    }
+                }
+            }
+        }
+
+        this.confirmMarkAllStudied.set(null);
+    }
+
+    protected cancelMarkAllStudied(): void {
+        this.confirmMarkAllStudied.set(null);
+    }
+
     protected topicLastStudiedHint(cat: StudyCategorySection, sub: StudySubtopicSection): TopicLastStudiedHint {
         return this.topicLastStudiedById().get(this.topicId(cat, sub)) ?? { kind: 'none' };
     }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -190,7 +190,12 @@
         "removeAllAria": "Remove all done topics from today's plan",
         "removeAllConfirm": "Remove all?",
         "removeAllYes": "Yes",
-        "removeAllNo": "Cancel"
+        "removeAllNo": "Cancel",
+        "markAllStudied": "Mark all as studied",
+        "markAllStudiedAria": "Mark all selected topics as studied",
+        "markAllStudiedCatAria": "Mark all {{cat}} topics as studied",
+        "markAllStudiedConfirm": "Mark all as studied?",
+        "markAllStudiedYes": "Yes, mark all"
     },
     "heatmap": {
         "heading": "Activity",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -190,7 +190,12 @@
         "removeAllAria": "Убрать все изученные темы из плана на сегодня",
         "removeAllConfirm": "Убрать все?",
         "removeAllYes": "Да",
-        "removeAllNo": "Отмена"
+        "removeAllNo": "Отмена",
+        "markAllStudied": "Отметить все как изученные",
+        "markAllStudiedAria": "Отметить все выбранные темы как изученные",
+        "markAllStudiedCatAria": "Отметить все темы {{cat}} как изученные",
+        "markAllStudiedConfirm": "Отметить все как изученные?",
+        "markAllStudiedYes": "Да, отметить"
     },
     "heatmap": {
         "heading": "Активность",


### PR DESCRIPTION
## Summary

- Added a global **"Mark all as studied"** button in the "To study" summary column — marks all currently selected (not yet studied) topics at once
- Added a per-category **"Mark all as studied"** button next to each category heading in the topic picker — scoped to selected topics in that category only
- Both show an inline confirmation prompt before applying to avoid accidental clicks
- Both call `TodayPlanService.markStudied()` so activity stats update correctly

## Files changed

| File | Change |
|------|--------|
| `plan-page.component.ts` | `confirmMarkAllStudied` signal; `categorySelectedUnstudiedCount()`, `requestMarkAllStudied()`, `confirmMarkAllStudiedTopics()`, `cancelMarkAllStudied()` methods |
| `plan-page.component.html` | Global button in "To study" summary column; per-category buttons in topic picker |
| `plan-page.component.scss` | `.plan__cat-heading-row` flex layout for heading + button |
| `plan-page.component.spec.ts` | 8 unit tests covering signal state and bulk-mark logic |
| `en.json` / `ru.json` | `markAllStudied*` translation keys |
| `docs/issues-priority.md` | Mark #54 done |

## Acceptance criteria

- [x] Only affects topics that are currently selected in the plan
- [x] Respects `TodayPlanService.markStudied()` so stats update correctly
- [x] Confirmation prompt before bulk-marking to avoid accidental clicks

Closes #54

🤖 Generated with [Claude Code](https://claude.ai/claude-code)