### PR TITLE
Fix #39: Add full-text search to the study guide

### DIFF
--- a/docs/issues-priority.md
+++ b/docs/issues-priority.md
@@ -14,7 +14,7 @@ Generated 2026-05-06. Based on labels, dependencies, and effort/value assessment
 | ~~[#55](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/55)~~ | ~~Collapsible code examples in study guide~~ | ✅ Done |
 | [#54](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/54) | Bulk "Mark all as studied" in plan | Low effort, plan page already has the logic |
 | ~~[#40](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/40)~~ | ~~Difficulty filter in study guide~~ | ✅ Done — [PR #73](https://github.com/ZhannaM85/interview-trainer-angular-app/pull/73) |
-| [#39](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/39) | Full-text search in study guide | In-memory filter, naturally pairs with #40 |
+| ~~[#39](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/39)~~ | ~~Full-text search in study guide~~ | ✅ Done |
 
 ---
 

--- a/e2e/study-guide.spec.ts
+++ b/e2e/study-guide.spec.ts
@@ -53,6 +53,82 @@ test.describe('Study guide difficulty filter', () => {
     });
 });
 
+test.describe('Study guide full-text search', () => {
+    test('search input is visible on the study guide page', async ({ page }) => {
+        await page.goto('/study');
+        const input = page.locator('.study__search-input');
+        await expect(input).toBeVisible({ timeout: 10_000 });
+    });
+
+    test('typing a query filters questions and shows result count', async ({ page }) => {
+        await page.goto('/study');
+        await expect(page.locator('.study__search-input')).toBeVisible({ timeout: 10_000 });
+
+        await page.locator('.study__search-input').fill('what');
+        await expect(page.locator('.study__search-count')).toBeVisible();
+        await expect(page.locator('.study__cat')).not.toHaveCount(0);
+    });
+
+    test('search expands all subtopic accordions automatically', async ({ page }) => {
+        await page.goto('/study');
+        await expect(page.locator('.study__search-input')).toBeVisible({ timeout: 10_000 });
+
+        // Collapse everything first
+        const collapseBtn = page.locator('.study__expand-collapse-all');
+        if (await collapseBtn.isVisible()) {
+            // Click until text indicates collapsed (if possible); just click once to get a consistent state
+            await collapseBtn.click();
+        }
+
+        await page.locator('.study__search-input').fill('closure');
+
+        // All visible accordions should be open
+        const accordions = page.locator('.study__sub-accordion');
+        const count = await accordions.count();
+        for (let i = 0; i < count; i++) {
+            await expect(accordions.nth(i)).toHaveClass(/study__sub-accordion--open/);
+        }
+    });
+
+    test('shows no-results message when query matches nothing', async ({ page }) => {
+        await page.goto('/study');
+        await expect(page.locator('.study__search-input')).toBeVisible({ timeout: 10_000 });
+
+        await page.locator('.study__search-input').fill('xyzabcnotfound123');
+        await expect(page.locator('.study__message')).toBeVisible();
+        await expect(page.locator('.study__cat')).toHaveCount(0);
+    });
+
+    test('clearing the search restores the full guide', async ({ page }) => {
+        await page.goto('/study');
+        await expect(page.locator('.study__search-input')).toBeVisible({ timeout: 10_000 });
+
+        await page.locator('.study__search-input').fill('xyzabcnotfound123');
+        await expect(page.locator('.study__message')).toBeVisible();
+
+        await page.locator('.study__search-input').fill('');
+        await expect(page.locator('.study__cat')).not.toHaveCount(0);
+        await expect(page.locator('.study__search-count')).not.toBeVisible();
+    });
+
+    test('search works together with the difficulty filter', async ({ page }) => {
+        await page.goto('/study');
+        await expect(page.locator('.study__search-input')).toBeVisible({ timeout: 10_000 });
+
+        // Apply difficulty filter first
+        await page.locator('.study__difficulty-row button').nth(1).click();
+        // Then search
+        await page.locator('.study__search-input').fill('what');
+
+        const diffBtn = page.locator('.study__difficulty-row button').nth(1);
+        await expect(diffBtn).toHaveAttribute('aria-pressed', 'true');
+        // Either results or no-results message should be visible
+        const hasCats = await page.locator('.study__cat').count();
+        const hasMsg = await page.locator('.study__message').count();
+        expect(hasCats + hasMsg).toBeGreaterThan(0);
+    });
+});
+
 test.describe('Study guide collapsible code examples', () => {
     async function openFirstSubtopic(page: Parameters<typeof test>[1]['page']): Promise<Locator> {
         await page.goto('/study');

--- a/src/app/features/study/pages/study-guide-page/study-guide-page.component.html
+++ b/src/app/features/study/pages/study-guide-page/study-guide-page.component.html
@@ -46,6 +46,22 @@
         }
     </div>
 
+    <div class="study__search-wrap">
+        <input
+            type="search"
+            class="study__search-input"
+            [placeholder]="'study.searchPlaceholder' | translate"
+            [attr.aria-label]="'study.searchLabel' | translate"
+            [value]="searchQuery()"
+            (input)="onSearchInput($event)"
+        />
+        @if (searchActive()) {
+            <p class="study__search-count" role="status" aria-live="polite">
+                {{ 'study.searchResultCount' | translate: { count: searchResultCount() } }}
+            </p>
+        }
+    </div>
+
     @if (showPlanCompleteBanner()) {
         <div
             id="study-plan-complete-banner"
@@ -114,6 +130,8 @@
         <p class="study__message">{{ 'study.untouchedFilterEmpty' | translate }}</p>
     } @else if (filterMode() === 'never-studied' && sections().length === 0) {
         <p class="study__message">{{ 'studyFilter.neverStudiedEmpty' | translate }}</p>
+    } @else if (searchActive() && sections().length === 0) {
+        <p class="study__message">{{ 'study.searchNoResults' | translate }}</p>
     } @else {
         <div class="study__layout">
             <details
@@ -311,7 +329,7 @@
                                                 <span class="study__q-num">{{
                                                     globalOrdinalByQuestionId().get(q.id)
                                                 }}.</span>
-                                                {{ qParts.lead }}
+                                                <span [innerHTML]="qParts.lead | searchHighlight:searchQueryTrimmed()"></span>
                                             </h4>
                                         </div>
                                         @if (qParts.code) {

--- a/src/app/features/study/pages/study-guide-page/study-guide-page.component.scss
+++ b/src/app/features/study/pages/study-guide-page/study-guide-page.component.scss
@@ -97,7 +97,47 @@
 }
 
 .study__difficulty-row {
+    margin-bottom: 0.65rem;
+}
+
+.study__search-wrap {
     margin-bottom: 0.85rem;
+}
+
+.study__search-input {
+    display: block;
+    width: 100%;
+    padding: 0.5rem 0.85rem;
+    border-radius: 0.55rem;
+    border: 1px solid var(--it-border);
+    background: var(--it-card);
+    color: var(--it-text);
+    font: inherit;
+    font-size: 0.9rem;
+    box-sizing: border-box;
+    transition: border-color 0.12s ease;
+}
+
+.study__search-input:focus {
+    outline: none;
+    border-color: var(--it-accent);
+}
+
+.study__search-input::placeholder {
+    color: var(--it-text-muted);
+}
+
+.study__search-count {
+    margin: 0.4rem 0 0;
+    font-size: 0.82rem;
+    color: var(--it-text-muted);
+}
+
+.study__search-highlight {
+    background: color-mix(in srgb, var(--it-accent) 25%, transparent);
+    color: inherit;
+    border-radius: 0.2rem;
+    padding: 0 0.05em;
 }
 
 .study__expand-collapse-all {

--- a/src/app/features/study/pages/study-guide-page/study-guide-page.component.ts
+++ b/src/app/features/study/pages/study-guide-page/study-guide-page.component.ts
@@ -18,12 +18,14 @@ import { ProgressService } from '../../../../core/services/progress.service';
 import { TodayPlanService } from '../../../../core/services/today-plan.service';
 import { QuestionService } from '../../../../core/services/question.service';
 import { AnswerBlocksComponent } from '../../../../shared/components/answer-blocks/answer-blocks.component';
+import { SearchHighlightPipe } from '../../../../shared/pipes/search-highlight.pipe';
 import { SplitQuestionCodePipe } from '../../../../shared/pipes/split-question-code.pipe';
 import type { Question, QuestionDifficulty } from '../../../../shared/models/question.model';
 import { topicIdFromParts } from '../../../../shared/utils/topic-key.utils';
 import {
     buildStudyGuideSections,
     filterStudyGuideSectionsByDifficulty,
+    filterStudyGuideSectionsBySearch,
     filterStudyGuideSectionsByTopicIds,
     filterStudyGuideSectionsExcludingTopicIds,
     filterStudyGuideSectionsWithoutPractice,
@@ -54,7 +56,7 @@ function isSameLocalCalendarDay(a: Date, b: Date): boolean {
 
 @Component({
     selector: 'app-study-guide-page',
-    imports: [AnswerBlocksComponent, RouterLink, SplitQuestionCodePipe, TranslatePipe],
+    imports: [AnswerBlocksComponent, RouterLink, SearchHighlightPipe, SplitQuestionCodePipe, TranslatePipe],
     templateUrl: './study-guide-page.component.html',
     styleUrl: './study-guide-page.component.scss',
     changeDetection: ChangeDetectionStrategy.OnPush
@@ -108,6 +110,10 @@ export class StudyGuidePageComponent {
     protected readonly difficultyFilters: readonly StudyDifficultyFilter[] = ['all', 'beginner', 'intermediate', 'advanced'];
 
     protected readonly difficultyFilter = signal<StudyDifficultyFilter>('all');
+
+    protected readonly searchQuery = signal('');
+    protected readonly searchQueryTrimmed = computed(() => this.searchQuery().trim().toLowerCase());
+    protected readonly searchActive = computed(() => this.searchQueryTrimmed().length > 0);
 
     protected readonly filterMode = toSignal(
         this.route.queryParamMap.pipe(
@@ -188,7 +194,21 @@ export class StudyGuidePageComponent {
         if (diff !== 'all') {
             all = filterStudyGuideSectionsByDifficulty(all, diff);
         }
+        const sq = this.searchQueryTrimmed();
+        if (sq) {
+            all = filterStudyGuideSectionsBySearch(all, sq);
+        }
         return all;
+    });
+
+    protected readonly searchResultCount = computed(() => {
+        let count = 0;
+        for (const cat of this.sections()) {
+            for (const sub of cat.subtopics) {
+                count += sub.questions.length;
+            }
+        }
+        return count;
     });
 
     protected readonly planTodayFilterActive = computed(() => {
@@ -275,6 +295,7 @@ export class StudyGuidePageComponent {
     }
 
     protected subtopicAccordionOpen(cat: StudyCategorySection, sub: StudySubtopicSection): boolean {
+        if (this.searchActive()) return true;
         const id = topicIdFromParts(cat.category, sub.subtopic);
         const m = this.subtopicAccordionState();
         if (m.has(id)) {
@@ -392,6 +413,10 @@ export class StudyGuidePageComponent {
 
     protected setDifficultyFilter(f: StudyDifficultyFilter): void {
         this.difficultyFilter.set(f);
+    }
+
+    protected onSearchInput(event: Event): void {
+        this.searchQuery.set((event.target as HTMLInputElement).value);
     }
 
     protected setFilterMode(mode: StudyFilterMode): void {

--- a/src/app/features/study/study-guide-grouping.spec.ts
+++ b/src/app/features/study/study-guide-grouping.spec.ts
@@ -1,16 +1,17 @@
-import { buildStudyGuideSections, filterStudyGuideSectionsByDifficulty } from './study-guide-grouping';
+import { buildStudyGuideSections, filterStudyGuideSectionsByDifficulty, filterStudyGuideSectionsBySearch } from './study-guide-grouping';
 import type { Question } from '../../shared/models/question.model';
 
 function makeQuestion(
     id: number,
     category: 'javascript' | 'angular',
     subtopic: string,
-    difficulty: 'beginner' | 'intermediate' | 'advanced'
+    difficulty: 'beginner' | 'intermediate' | 'advanced',
+    overrides: Partial<{ question: string; answer: string }> = {}
 ): Question {
     return {
         id,
-        question: `Q${id}`,
-        answer: '',
+        question: overrides.question ?? `Q${id}`,
+        answer: overrides.answer ?? '',
         weakAnswer: '',
         technicalAnswer: '',
         interviewAnswer: '',
@@ -21,6 +22,58 @@ function makeQuestion(
         difficulty
     };
 }
+
+describe('filterStudyGuideSectionsBySearch', () => {
+    const questions: Question[] = [
+        makeQuestion(1, 'javascript', 'closures', 'beginner', { question: 'What is a closure?', answer: 'A function retaining its scope.' }),
+        makeQuestion(2, 'javascript', 'closures', 'intermediate', { question: 'Closure use cases', answer: 'Data encapsulation.' }),
+        makeQuestion(3, 'angular', 'signals', 'beginner', { question: 'What are Angular signals?', answer: 'Reactive primitives.' }),
+        makeQuestion(4, 'angular', 'pipes', 'beginner', { question: 'Built-in pipes', answer: 'DatePipe, CurrencyPipe.' })
+    ];
+
+    const sections = buildStudyGuideSections(questions);
+
+    it('returns all sections when query is empty', () => {
+        expect(filterStudyGuideSectionsBySearch(sections, '')).toStrictEqual(sections);
+    });
+
+    it('matches by question text (case-insensitive)', () => {
+        const result = filterStudyGuideSectionsBySearch(sections, 'closure');
+        expect(result).toHaveLength(1);
+        expect(result[0].category).toBe('javascript');
+        expect(result[0].subtopics[0].questions.map((q) => q.id)).toEqual([1, 2]);
+    });
+
+    it('matches by answer text', () => {
+        const result = filterStudyGuideSectionsBySearch(sections, 'reactive');
+        expect(result).toHaveLength(1);
+        expect(result[0].subtopics[0].questions[0].id).toBe(3);
+    });
+
+    it('matches by subtopic name and includes all questions in that subtopic', () => {
+        const result = filterStudyGuideSectionsBySearch(sections, 'signals');
+        expect(result).toHaveLength(1);
+        expect(result[0].subtopics[0].subtopic).toBe('signals');
+        expect(result[0].subtopics[0].questions).toHaveLength(1);
+    });
+
+    it('drops subtopics with no matching questions', () => {
+        const result = filterStudyGuideSectionsBySearch(sections, 'datepipe');
+        expect(result).toHaveLength(1);
+        expect(result[0].subtopics).toHaveLength(1);
+        expect(result[0].subtopics[0].subtopic).toBe('pipes');
+    });
+
+    it('drops categories with no matches', () => {
+        const result = filterStudyGuideSectionsBySearch(sections, 'reactive');
+        const categories = result.map((c) => c.category);
+        expect(categories).not.toContain('javascript');
+    });
+
+    it('returns empty array when nothing matches', () => {
+        expect(filterStudyGuideSectionsBySearch(sections, 'xyznotfound')).toHaveLength(0);
+    });
+});
 
 describe('filterStudyGuideSectionsByDifficulty', () => {
     const questions: Question[] = [

--- a/src/app/features/study/study-guide-grouping.ts
+++ b/src/app/features/study/study-guide-grouping.ts
@@ -118,6 +118,38 @@ export function filterStudyGuideSectionsByDifficulty(
     return out;
 }
 
+/**
+ * Keep only questions whose `question`, `answer`, or `subtopic` (case-insensitive) contains `query`.
+ * If the subtopic name itself matches, all its questions are kept.
+ * Drops empty subtopics/categories. Expects `query` to be already lowercased and trimmed.
+ */
+export function filterStudyGuideSectionsBySearch(
+    sections: StudyCategorySection[],
+    query: string
+): StudyCategorySection[] {
+    const out: StudyCategorySection[] = [];
+    for (const cat of sections) {
+        const subs: StudySubtopicSection[] = [];
+        for (const sub of cat.subtopics) {
+            const subtopicMatches = sub.subtopic.toLowerCase().includes(query);
+            const questions = subtopicMatches
+                ? sub.questions
+                : sub.questions.filter(
+                      (q) =>
+                          q.question.toLowerCase().includes(query) ||
+                          q.answer.toLowerCase().includes(query)
+                  );
+            if (questions.length > 0) {
+                subs.push({ ...sub, questions });
+            }
+        }
+        if (subs.length > 0) {
+            out.push({ ...cat, subtopics: subs });
+        }
+    }
+    return out;
+}
+
 /** Keep only subtopics whose `category:subtopic` id is NOT in `topicIds`. Drops empty categories. */
 export function filterStudyGuideSectionsExcludingTopicIds(
     sections: StudyCategorySection[],

--- a/src/app/shared/pipes/search-highlight.pipe.spec.ts
+++ b/src/app/shared/pipes/search-highlight.pipe.spec.ts
@@ -1,0 +1,55 @@
+import { TestBed } from '@angular/core/testing';
+import { DomSanitizer, type SafeHtml } from '@angular/platform-browser';
+import { SecurityContext } from '@angular/core';
+import { SearchHighlightPipe } from './search-highlight.pipe';
+
+describe('SearchHighlightPipe', () => {
+    let pipe: SearchHighlightPipe;
+    let sanitizer: DomSanitizer;
+
+    function asString(value: SafeHtml | string): string {
+        if (typeof value === 'string') return value;
+        return sanitizer.sanitize(SecurityContext.HTML, value) ?? '';
+    }
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({});
+        sanitizer = TestBed.inject(DomSanitizer);
+        pipe = TestBed.runInInjectionContext(() => new SearchHighlightPipe());
+    });
+
+    it('returns the original text unchanged when query is empty', () => {
+        expect(pipe.transform('Hello world', '')).toBe('Hello world');
+    });
+
+    it('returns the original text unchanged when text is empty', () => {
+        expect(pipe.transform('', 'hello')).toBe('');
+    });
+
+    it('wraps the matched term in a <mark> tag', () => {
+        const result = asString(pipe.transform('Hello world', 'world'));
+        expect(result).toContain('<mark class="study__search-highlight">world</mark>');
+    });
+
+    it('is case-insensitive', () => {
+        const result = asString(pipe.transform('Hello World', 'hello'));
+        expect(result).toContain('<mark class="study__search-highlight">Hello</mark>');
+    });
+
+    it('highlights all occurrences', () => {
+        const result = asString(pipe.transform('foo bar foo', 'foo'));
+        const matches = result.match(/<mark/g) ?? [];
+        expect(matches).toHaveLength(2);
+    });
+
+    it('HTML-escapes the base text before highlighting', () => {
+        const result = asString(pipe.transform('<b>bold</b>', 'bold'));
+        expect(result).toContain('&lt;');
+        expect(result).toContain('&gt;');
+        expect(result).not.toContain('<b>');
+    });
+
+    it('escapes regex special characters in query', () => {
+        expect(() => pipe.transform('some text (here)', '(here)')).not.toThrow();
+    });
+});

--- a/src/app/shared/pipes/search-highlight.pipe.ts
+++ b/src/app/shared/pipes/search-highlight.pipe.ts
@@ -1,0 +1,21 @@
+import { inject, Pipe, type PipeTransform } from '@angular/core';
+import { DomSanitizer, type SafeHtml } from '@angular/platform-browser';
+
+@Pipe({ name: 'searchHighlight', standalone: true, pure: true })
+export class SearchHighlightPipe implements PipeTransform {
+    private readonly sanitizer = inject(DomSanitizer);
+
+    transform(text: string, query: string): SafeHtml | string {
+        if (!query || !text) return text;
+        const escapedText = text
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+        const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const highlighted = escapedText.replace(
+            new RegExp(`(${escapedQuery})`, 'gi'),
+            '<mark class="study__search-highlight">$1</mark>'
+        );
+        return this.sanitizer.bypassSecurityTrustHtml(highlighted);
+    }
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -147,7 +147,11 @@
         "lastPracticeAria": "Last answered in Practice on {{date}}",
         "expandCollapseAll": "Expand / collapse all",
         "filteredRetryBanner": "Showing topics you had trouble with recently.",
-        "filteredRetryClear": "Show all topics"
+        "filteredRetryClear": "Show all topics",
+        "searchPlaceholder": "Search questions…",
+        "searchLabel": "Search study guide",
+        "searchResultCount": "{{count}} question(s) found",
+        "searchNoResults": "No questions match your search."
     },
     "studyDifficulty": {
         "label": "Filter by difficulty"

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -147,7 +147,11 @@
         "lastPracticeAria": "Последний ответ в практике: {{date}}",
         "expandCollapseAll": "Развернуть / свернуть всё",
         "filteredRetryBanner": "Показаны темы, с которыми были затруднения недавно.",
-        "filteredRetryClear": "Показать все темы"
+        "filteredRetryClear": "Показать все темы",
+        "searchPlaceholder": "Поиск вопросов…",
+        "searchLabel": "Поиск по справочнику",
+        "searchResultCount": "Найдено вопросов: {{count}}",
+        "searchNoResults": "Ничего не найдено."
     },
     "studyDifficulty": {
         "label": "Фильтр по сложности"


### PR DESCRIPTION
## Summary

- Added a real-time full-text search input at the top of the study guide that filters questions as the user types, matching against question text, answer text, and subtopic name
- Added `filterStudyGuideSectionsBySearch()` to `study-guide-grouping.ts` — drops non-matching questions/subtopics/categories while keeping the entire subtopic when its name matches the query
- Added `SearchHighlightPipe` (`search-highlight.pipe.ts`) that wraps matched terms in `<mark class="study__search-highlight">` with safe HTML handling and HTML-entity escaping
- Wired the search state into the existing `sections()` computed signal so it composes naturally with the difficulty, today, and topics filters
- Expanded all subtopic accordions automatically when a search is active
- Added English and Russian translation keys for the placeholder, aria-label, result count, and no-results message
- Marked issue #39 as done in `docs/issues-priority.md`

## Files changed

| File | Change |
|------|--------|
| `src/app/features/study/study-guide-grouping.ts` | Added `filterStudyGuideSectionsBySearch()` |
| `src/app/features/study/study-guide-grouping.spec.ts` | Unit tests for the new filter function |
| `src/app/shared/pipes/search-highlight.pipe.ts` | New pipe — wraps matched terms in `<mark>` |
| `src/app/shared/pipes/search-highlight.pipe.spec.ts` | Unit tests for the highlight pipe |
| `src/app/features/study/pages/study-guide-page/study-guide-page.component.ts` | `searchQuery` signal, `onSearchInput`, wired into `sections()` |
| `src/app/features/study/pages/study-guide-page/study-guide-page.component.html` | Search input, result count, no-results message |
| `src/app/features/study/pages/study-guide-page/study-guide-page.component.scss` | Styles for search input, count, and highlight mark |
| `src/assets/i18n/en.json` | `study.searchPlaceholder`, `searchLabel`, `searchResultCount`, `searchNoResults` |
| `src/assets/i18n/ru.json` | Russian equivalents of the above keys |
| `e2e/study-guide.spec.ts` | E2E tests for the full-text search feature |
| `docs/issues-priority.md` | Marked #39 as done |

## Acceptance criteria

- [x] A search input is visible at the top of the study guide page
- [x] Typing a query filters questions in real-time (matches question text, answer text, subtopic name)
- [x] Matched term is highlighted in the filtered results
- [x] Works alongside existing `?today=1` and `?topics=` URL filters
- [x] Shows result count while search is active
- [x] Shows a "no results" message when nothing matches
- [x] Clearing the search restores the full guide

Closes #39

🤖 Generated with [mouse-fixes](https://github.com/ZhannaM85/mouse-fixes)
