### PR TITLE
Fix #50: Add session length selection before starting a quiz

### DIFF
--- a/docs/issues-priority.md
+++ b/docs/issues-priority.md
@@ -31,7 +31,7 @@ Generated 2026-05-06. Based on labels, dependencies, and effort/value assessment
 
 | # | Issue | Notes |
 |---|-------|-------|
-| [#50](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/50) | Session length picker | Standalone, no dependencies |
+| ~~[#50](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/50)~~ | ~~Session length picker~~ | ✅ Done |
 | [#53](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/53) | Carry over unfinished plan topics | Standalone; #57 depends on it |
 | [#44](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/44) | Save and resume incomplete session | **Unlocks #60** — do before it |
 | [#60](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/60) | Resume session nudge on app load | Depends on #44 |

--- a/e2e/practice-answer-question.spec.ts
+++ b/e2e/practice-answer-question.spec.ts
@@ -1,8 +1,30 @@
 import { test, expect } from '@playwright/test';
 
+test.describe('Practice / session mode picker', () => {
+  test('shows session mode picker before quiz starts', async ({ page }) => {
+    await page.goto('/quiz');
+    await expect(page.locator('.quiz__session-picker')).toBeVisible();
+    await expect(page.locator('.quiz__session-mode-btn')).toHaveCount(3);
+  });
+
+  test('starts quiz after picking a mode', async ({ page }) => {
+    await page.goto('/quiz');
+    await page.locator('.quiz__session-mode-btn').nth(1).click();
+    await expect(page.locator('.quiz__session-picker')).not.toBeVisible();
+    await expect(page.locator('.interview-q__cta')).toBeVisible({ timeout: 60_000 });
+  });
+
+  test('hides picker after selection', async ({ page }) => {
+    await page.goto('/quiz');
+    await page.locator('.quiz__session-mode-btn').first().click();
+    await expect(page.locator('.quiz__session-picker')).not.toBeVisible();
+  });
+});
+
 test.describe('Practice / quiz answer phase', () => {
   test('question sits on the same styled card as answers', async ({ page }) => {
     await page.goto('/quiz');
+    await page.locator('.quiz__session-mode-btn').nth(1).click();
     await expect(page.locator('.interview-q__cta')).toBeVisible({ timeout: 60_000 });
     await page.locator('.interview-q__cta').click();
 

--- a/src/app/core/services/question.service.ts
+++ b/src/app/core/services/question.service.ts
@@ -98,13 +98,14 @@ export class QuestionService {
         this.storage.set('quiz-shuffle', next);
     }
 
-    initializeQueue(questions: Question[]): void {
+    initializeQueue(questions: Question[], limit?: number): Question[] {
         const q = [...questions];
         if (this.shuffleEnabled()) {
             this.shuffleInPlace(q);
         }
-        this.queue = q;
+        this.queue = limit != null ? q.slice(0, limit) : q;
         this.index = -1;
+        return this.queue;
     }
 
     getNextQuestion(): Question | null {

--- a/src/app/features/quiz/pages/quiz-page/quiz-page.component.html
+++ b/src/app/features/quiz/pages/quiz-page/quiz-page.component.html
@@ -6,7 +6,40 @@
 >
     <h1 id="quiz-title" class="quiz__title visually-hidden">{{ 'quiz.titleHidden' | translate }}</h1>
 
-    @if (loadError()) {
+    @if (showSessionModePicker()) {
+        <div class="quiz__session-picker card-phase" role="region" aria-labelledby="session-picker-title">
+            <h2 id="session-picker-title" class="quiz__session-picker-title">{{ 'quiz.sessionPickerTitle' | translate }}</h2>
+            <div class="quiz__session-picker-options" role="group" [attr.aria-label]="'quiz.sessionPickerOptionsAria' | translate">
+                <button
+                    type="button"
+                    class="quiz__session-mode-btn"
+                    [class.quiz__session-mode-btn--selected]="sessionMode() === 'quick'"
+                    (click)="startSession('quick')"
+                >
+                    <span class="quiz__session-mode-name">{{ 'quiz.sessionModeQuick' | translate }}</span>
+                    <span class="quiz__session-mode-desc">{{ 'quiz.sessionModeQuickDesc' | translate }}</span>
+                </button>
+                <button
+                    type="button"
+                    class="quiz__session-mode-btn"
+                    [class.quiz__session-mode-btn--selected]="sessionMode() === 'standard'"
+                    (click)="startSession('standard')"
+                >
+                    <span class="quiz__session-mode-name">{{ 'quiz.sessionModeStandard' | translate }}</span>
+                    <span class="quiz__session-mode-desc">{{ 'quiz.sessionModeStandardDesc' | translate }}</span>
+                </button>
+                <button
+                    type="button"
+                    class="quiz__session-mode-btn"
+                    [class.quiz__session-mode-btn--selected]="sessionMode() === 'deep'"
+                    (click)="startSession('deep')"
+                >
+                    <span class="quiz__session-mode-name">{{ 'quiz.sessionModeDeep' | translate }}</span>
+                    <span class="quiz__session-mode-desc">{{ 'quiz.sessionModeDeepDesc' | translate }}</span>
+                </button>
+            </div>
+        </div>
+    } @else if (loadError()) {
         <p class="quiz__message quiz__message--error" role="alert">{{ 'quiz.loadError' | translate }}</p>
     } @else if (loading()) {
         <p class="quiz__message">{{ 'quiz.loading' | translate }}</p>
@@ -169,6 +202,10 @@
                     }
                 </ul>
             </div>
+        }
+
+        @if (sessionTruncated()) {
+            <p class="quiz__hint" role="status">{{ 'quiz.sessionFewNote' | translate: { count: sessionTotal() } }}</p>
         }
 
         @if (sessionProgressCounts(); as prog) {

--- a/src/app/features/quiz/pages/quiz-page/quiz-page.component.scss
+++ b/src/app/features/quiz/pages/quiz-page/quiz-page.component.scss
@@ -512,3 +512,79 @@
     color: var(--it-accent);
     background: var(--it-accent-dim);
 }
+
+.quiz__session-picker {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.25rem;
+    width: 100%;
+    max-width: 28rem;
+    align-self: center;
+    padding: 1.75rem 1.5rem;
+    text-align: center;
+    animation: quiz-phase-in 0.28s ease;
+}
+
+.quiz__session-picker-title {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+}
+
+.quiz__session-picker-options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    width: 100%;
+}
+
+.quiz__session-mode-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.15rem;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    border: 1px solid var(--it-border);
+    background: var(--it-card);
+    color: var(--it-text);
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: border-color 0.12s ease, background 0.12s ease;
+    box-sizing: border-box;
+}
+
+.quiz__session-mode-btn:hover {
+    border-color: var(--it-accent);
+}
+
+.quiz__session-mode-btn:focus-visible {
+    outline: 2px solid var(--it-focus);
+    outline-offset: 3px;
+}
+
+.quiz__session-mode-btn--selected {
+    border-color: var(--it-accent);
+    background: var(--it-accent-dim);
+    color: var(--it-accent);
+}
+
+.quiz__session-mode-name {
+    font-weight: 700;
+    font-size: 0.95rem;
+}
+
+.quiz__session-mode-desc {
+    font-size: 0.82rem;
+    color: var(--it-text-muted);
+    line-height: 1.4;
+}
+
+.quiz__session-mode-btn--selected .quiz__session-mode-desc {
+    color: inherit;
+    opacity: 0.8;
+}

--- a/src/app/features/quiz/pages/quiz-page/quiz-page.component.spec.ts
+++ b/src/app/features/quiz/pages/quiz-page/quiz-page.component.spec.ts
@@ -4,7 +4,7 @@ import { provideRouter } from '@angular/router';
 import { TranslateLoader, provideTranslateService, type TranslationObject } from '@ngx-translate/core';
 import { Observable, of } from 'rxjs';
 
-import { QuizPageComponent } from './quiz-page.component';
+import { QuizPageComponent, type SessionMode } from './quiz-page.component';
 import { QuestionService } from '../../../../core/services/question.service';
 
 class StubLoader implements TranslateLoader {
@@ -14,22 +14,32 @@ class StubLoader implements TranslateLoader {
                 titleHidden: 'Quiz',
                 loading: 'Loading…',
                 shuffleOn: 'Shuffle: On',
-                shuffleOff: 'Shuffle: Off'
+                shuffleOff: 'Shuffle: Off',
+                sessionPickerTitle: 'Choose session length',
+                sessionPickerOptionsAria: 'Session length options',
+                sessionModeQuick: 'Quick',
+                sessionModeQuickDesc: '5 questions',
+                sessionModeStandard: 'Standard',
+                sessionModeStandardDesc: '15 questions',
+                sessionModeDeep: 'Deep',
+                sessionModeDeepDesc: 'All due'
             }
         });
     }
 }
+
+const testProviders = [
+    provideHttpClient(),
+    provideRouter([]),
+    ...provideTranslateService({ loader: { provide: TranslateLoader, useClass: StubLoader } })
+];
 
 describe('QuizPageComponent — shuffle toggle', () => {
     beforeEach(async () => {
         localStorage.clear();
         await TestBed.configureTestingModule({
             imports: [QuizPageComponent],
-            providers: [
-                provideHttpClient(),
-                provideRouter([]),
-                ...provideTranslateService({ loader: { provide: TranslateLoader, useClass: StubLoader } })
-            ]
+            providers: testProviders
         }).compileComponents();
     });
 
@@ -49,5 +59,62 @@ describe('QuizPageComponent — shuffle toggle', () => {
         const before = questionService.shuffleEnabled();
         component.toggleShuffle();
         expect(questionService.shuffleEnabled()).toBe(!before);
+    });
+});
+
+describe('QuizPageComponent — session mode picker', () => {
+    beforeEach(async () => {
+        localStorage.clear();
+        await TestBed.configureTestingModule({
+            imports: [QuizPageComponent],
+            providers: testProviders
+        }).compileComponents();
+    });
+
+    afterEach(() => TestBed.resetTestingModule());
+
+    it('shows session mode picker on load', () => {
+        const fixture = TestBed.createComponent(QuizPageComponent);
+        const component = fixture.componentInstance as unknown as { showSessionModePicker: () => boolean };
+        expect(component.showSessionModePicker()).toBe(true);
+    });
+
+    it('defaults to standard session mode when no saved preference', () => {
+        const fixture = TestBed.createComponent(QuizPageComponent);
+        const component = fixture.componentInstance as unknown as { sessionMode: () => SessionMode };
+        expect(component.sessionMode()).toBe('standard');
+    });
+
+    it('restores session mode from localStorage', () => {
+        localStorage.setItem('interview-trainer:quiz-session-mode', '"quick"');
+        const fixture = TestBed.createComponent(QuizPageComponent);
+        const component = fixture.componentInstance as unknown as { sessionMode: () => SessionMode };
+        expect(component.sessionMode()).toBe('quick');
+    });
+
+    it('startSession persists mode to localStorage and hides picker', () => {
+        const fixture = TestBed.createComponent(QuizPageComponent);
+        const component = fixture.componentInstance as unknown as {
+            startSession: (mode: SessionMode) => void;
+            showSessionModePicker: () => boolean;
+            sessionMode: () => SessionMode;
+        };
+        component.startSession('quick');
+        expect(component.sessionMode()).toBe('quick');
+        expect(component.showSessionModePicker()).toBe(false);
+        expect(localStorage.getItem('interview-trainer:quiz-session-mode')).toBe('"quick"');
+    });
+
+    it('restartSession shows picker again', () => {
+        const fixture = TestBed.createComponent(QuizPageComponent);
+        const component = fixture.componentInstance as unknown as {
+            startSession: (mode: SessionMode) => void;
+            restartSession: () => void;
+            showSessionModePicker: () => boolean;
+        };
+        component.startSession('standard');
+        expect(component.showSessionModePicker()).toBe(false);
+        component.restartSession();
+        expect(component.showSessionModePicker()).toBe(true);
     });
 });

--- a/src/app/features/quiz/pages/quiz-page/quiz-page.component.ts
+++ b/src/app/features/quiz/pages/quiz-page/quiz-page.component.ts
@@ -7,6 +7,7 @@ import { distinctUntilChanged, map, take } from 'rxjs';
 import { ActivityService } from '../../../../core/services/activity.service';
 import { ProgressService, SCORE_BY_RATING } from '../../../../core/services/progress.service';
 import { QuestionService } from '../../../../core/services/question.service';
+import { StorageService } from '../../../../core/services/storage.service';
 import { TodayPlanService } from '../../../../core/services/today-plan.service';
 import type { Progress } from '../../../../shared/models/progress.model';
 import type { Question, QuestionCategory } from '../../../../shared/models/question.model';
@@ -19,6 +20,13 @@ import { InterviewQuestionComponent } from '../../components/interview-question/
 import { SelfEvaluationComponent } from '../../components/self-evaluation/self-evaluation.component';
 
 export type QuizPhase = 'question' | 'answer' | 'feedback';
+export type SessionMode = 'quick' | 'standard' | 'deep';
+
+const SESSION_MODE_LIMIT: Record<SessionMode, number | undefined> = {
+    quick: 5,
+    standard: 15,
+    deep: undefined
+};
 
 export interface FeedbackSnapshot {
     headline: string;
@@ -65,6 +73,7 @@ export class QuizPageComponent {
     private readonly activityService = inject(ActivityService);
     private readonly translate = inject(TranslateService);
     private readonly route = inject(ActivatedRoute);
+    private readonly storage = inject(StorageService);
 
     /** `?topics=cat:sub` — when present, restrict the session to questions in those topic IDs. */
     private readonly topicsFocusParam = toSignal(
@@ -74,6 +83,12 @@ export class QuizPageComponent {
         ),
         { initialValue: this.route.snapshot.queryParamMap.get('topics') ?? '' }
     );
+
+    protected readonly sessionMode = signal<SessionMode>(
+        this.storage.get<SessionMode>('quiz-session-mode') ?? 'standard'
+    );
+    protected readonly showSessionModePicker = signal(true);
+    protected readonly sessionTruncated = signal(false);
 
     protected readonly currentQuestion = signal<Question | null>(null);
     protected readonly phase = signal<QuizPhase>('question');
@@ -190,13 +205,11 @@ export class QuizPageComponent {
                 this.rebuildFeedbackSnapshot();
             }
         });
-
-        this.loadQuiz();
     }
 
     @HostListener('document:keydown', ['$event'])
     protected handleKeydown(event: KeyboardEvent): void {
-        if (this.showPlanTopicsCoveredDialog() || this.loading() || this.sessionComplete() || !this.currentQuestion()) {
+        if (this.showSessionModePicker() || this.showPlanTopicsCoveredDialog() || this.loading() || this.sessionComplete() || !this.currentQuestion()) {
             return;
         }
         const target = event.target as HTMLElement;
@@ -283,8 +296,15 @@ export class QuizPageComponent {
         this.questionService.toggleShuffle();
     }
 
-    protected restartSession(): void {
+    protected startSession(mode: SessionMode): void {
+        this.sessionMode.set(mode);
+        this.storage.set('quiz-session-mode', mode);
+        this.showSessionModePicker.set(false);
         this.loadQuiz();
+    }
+
+    protected restartSession(): void {
+        this.showSessionModePicker.set(true);
     }
 
     protected switchToFullQuestionBank(): void {
@@ -381,6 +401,7 @@ export class QuizPageComponent {
         this.loadError.set(false);
         this.sessionComplete.set(false);
         this.showPlanTopicsCoveredDialog.set(false);
+        this.sessionTruncated.set(false);
         this.currentQuestion.set(null);
         this.phase.set('question');
         this.feedbackSnapshot.set(null);
@@ -441,10 +462,14 @@ export class QuizPageComponent {
                     }
                     this.usingFallbackQueue.set(useFallback);
                     const queue = fullBankMode ? candidate : useFallback ? candidate : due;
-                    this.sessionTotal.set(queue.length);
+                    const limit = SESSION_MODE_LIMIT[this.sessionMode()];
+                    this.sessionTruncated.set(
+                        limit != null && queue.length < limit && queue.length > 0
+                    );
+                    const finalQueue = this.questionService.initializeQueue(queue, limit);
+                    this.sessionTotal.set(finalQueue.length);
                     this.sessionIndex.set(0);
-                    this.sessionStackTopicIds.set(this.uniqueSortedTopicIds(queue));
-                    this.questionService.initializeQueue(queue);
+                    this.sessionStackTopicIds.set(this.uniqueSortedTopicIds(finalQueue));
                     this.loading.set(false);
                     this.advanceToNextQuestion();
                 },

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -305,7 +305,16 @@
         "summaryBestStreak": "Best streak: {{count}} nailed in a row",
         "doneGotoDashboard": "Progress",
         "shuffleOn": "Shuffle: On",
-        "shuffleOff": "Shuffle: Off"
+        "shuffleOff": "Shuffle: Off",
+        "sessionPickerTitle": "Choose session length",
+        "sessionPickerOptionsAria": "Session length options",
+        "sessionModeQuick": "Quick",
+        "sessionModeQuickDesc": "5 questions — ideal for a short warm-up",
+        "sessionModeStandard": "Standard",
+        "sessionModeStandardDesc": "15 questions — balanced daily practice",
+        "sessionModeDeep": "Deep",
+        "sessionModeDeepDesc": "All due questions — full review session",
+        "sessionFewNote": "Only {{count}} questions were available — using all of them."
     },
     "dashboard": {
         "title": "Interview Progress",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -305,7 +305,16 @@
         "summaryBestStreak": "Лучшая серия: {{count}} «отлично» подряд",
         "doneGotoDashboard": "Прогресс",
         "shuffleOn": "Перемешивание: вкл",
-        "shuffleOff": "Перемешивание: выкл"
+        "shuffleOff": "Перемешивание: выкл",
+        "sessionPickerTitle": "Выберите длину сессии",
+        "sessionPickerOptionsAria": "Варианты длины сессии",
+        "sessionModeQuick": "Быстро",
+        "sessionModeQuickDesc": "5 вопросов — быстрая разминка",
+        "sessionModeStandard": "Стандарт",
+        "sessionModeStandardDesc": "15 вопросов — сбалансированная ежедневная практика",
+        "sessionModeDeep": "Углублённо",
+        "sessionModeDeepDesc": "Все вопросы к повторению — полная сессия",
+        "sessionFewNote": "Доступно только {{count}} вопросов — используем все."
     },
     "dashboard": {
         "title": "Прогресс по собеседованиям",


### PR DESCRIPTION
## Summary

- Added a session mode picker (Quick / Standard / Deep) that appears before each quiz session starts, letting users control how many questions to practice
- Selection is persisted to `localStorage` (`quiz-session-mode` key) so it is remembered across sessions; defaults to Standard (15 questions)
- Queue slicing happens after shuffle in `QuestionService.initializeQueue()`, so randomization applies to the full candidate pool before trimming to the chosen limit
- When fewer questions are available than the selected limit, all available questions are used and a hint is shown

## Files changed

| File | Change |
|------|--------|
| `quiz-page.component.ts` | Added `SessionMode` type, `SESSION_MODE_LIMIT` constant, `sessionMode`/`showSessionModePicker`/`sessionTruncated` signals, `startSession()` method, updated `restartSession()` and `loadQuiz()` |
| `quiz-page.component.html` | Added session picker `@if` block at the top of the template; added `sessionTruncated` hint in active session |
| `quiz-page.component.scss` | Added styles for `.quiz__session-picker`, `.quiz__session-mode-btn`, and related modifier/element classes |
| `quiz-page.component.spec.ts` | Added 5 unit tests covering picker visibility, default mode, localStorage restore, `startSession`, and `restartSession` |
| `question.service.ts` | Extended `initializeQueue()` to accept an optional `limit` parameter and return the final (shuffled + sliced) queue |
| `en.json` / `ru.json` | Added `sessionPickerTitle`, `sessionModeQuick/Standard/Deep` + `Desc`, `sessionFewNote` keys in both locales |
| `e2e/practice-answer-question.spec.ts` | Added 3 picker E2E tests; updated existing answer-phase test to navigate through the picker first |
| `docs/issues-priority.md` | Marked issue #50 as ✅ Done |

## Acceptance criteria

- [x] Session mode picker (Quick / Standard / Deep) shown before the quiz starts
- [x] Selection remembered in localStorage for next session
- [x] If fewer questions available than the chosen limit, all available are used with a hint note
- [x] Deep mode uses all due questions with no cap
- [x] Unit tests and E2E tests updated/added

Closes #50

🤖 Generated with [mouse-fixes](https://github.com/ZhannaM85/mouse-fixes)
