### PR TITLE
Fix #53: Carry over unfinished plan topics to the next day

### DIFF
--- a/docs/issues-priority.md
+++ b/docs/issues-priority.md
@@ -32,7 +32,7 @@ Generated 2026-05-06. Based on labels, dependencies, and effort/value assessment
 | # | Issue | Notes |
 |---|-------|-------|
 | ~~[#50](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/50)~~ | ~~Session length picker~~ | ✅ Done |
-| [#53](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/53) | Carry over unfinished plan topics | Standalone; #57 depends on it |
+| ~~[#53](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/53)~~ | ~~Carry over unfinished plan topics~~ | ✅ Done |
 | [#44](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/44) | Save and resume incomplete session | **Unlocks #60** — do before it |
 | [#60](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/60) | Resume session nudge on app load | Depends on #44 |
 

--- a/e2e/plan-carryover.spec.ts
+++ b/e2e/plan-carryover.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test';
+
+function yesterdayStr(): string {
+    const d = new Date();
+    d.setDate(d.getDate() - 1);
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
+test.describe('Plan page — carryover unfinished topics', () => {
+    test('shows carryover banner when yesterday had unfinished topics', async ({ page }) => {
+        await page.addInitScript((yesterday) => {
+            localStorage.setItem(
+                'interview-trainer:today-plan',
+                JSON.stringify({
+                    planDate: yesterday,
+                    selectedTopicIds: ['javascript:closures', 'angular:signals'],
+                    studiedTopicIds: []
+                })
+            );
+        }, yesterdayStr());
+
+        await page.goto('/#/plan');
+        const banner = page.locator('.plan__carryover');
+        await expect(banner).toBeVisible({ timeout: 10_000 });
+        await expect(banner).toContainText('2');
+    });
+
+    test('does not show banner when all topics were studied', async ({ page }) => {
+        await page.addInitScript((yesterday) => {
+            localStorage.setItem(
+                'interview-trainer:today-plan',
+                JSON.stringify({
+                    planDate: yesterday,
+                    selectedTopicIds: ['javascript:closures'],
+                    studiedTopicIds: ['javascript:closures']
+                })
+            );
+        }, yesterdayStr());
+
+        await page.goto('/#/plan');
+        await expect(page.locator('.plan__title')).toBeVisible({ timeout: 10_000 });
+        await expect(page.locator('.plan__carryover')).not.toBeVisible();
+    });
+
+    test('dismissing the banner hides it and does not add topics to plan', async ({ page }) => {
+        await page.addInitScript((yesterday) => {
+            localStorage.setItem(
+                'interview-trainer:today-plan',
+                JSON.stringify({
+                    planDate: yesterday,
+                    selectedTopicIds: ['javascript:closures'],
+                    studiedTopicIds: []
+                })
+            );
+        }, yesterdayStr());
+
+        await page.goto('/#/plan');
+        const banner = page.locator('.plan__carryover');
+        await expect(banner).toBeVisible({ timeout: 10_000 });
+
+        await page.locator('.plan__carryover-dismiss').click();
+        await expect(banner).not.toBeVisible();
+
+        // Topics should NOT appear in the To study section
+        const toStudySection = page.locator('.plan__summary-col').first();
+        await expect(toStudySection.locator('.plan__summary-list')).not.toBeVisible();
+    });
+
+    test('accepting the banner adds topics to today plan and hides it', async ({ page }) => {
+        await page.addInitScript((yesterday) => {
+            localStorage.setItem(
+                'interview-trainer:today-plan',
+                JSON.stringify({
+                    planDate: yesterday,
+                    selectedTopicIds: ['javascript:closures'],
+                    studiedTopicIds: []
+                })
+            );
+        }, yesterdayStr());
+
+        await page.goto('/#/plan');
+        const banner = page.locator('.plan__carryover');
+        await expect(banner).toBeVisible({ timeout: 10_000 });
+
+        await page.locator('.plan__carryover-accept').click();
+        await expect(banner).not.toBeVisible();
+
+        // Topics should appear in the To study list
+        const toStudyList = page.locator('.plan__summary-list').first();
+        await expect(toStudyList).toBeVisible();
+    });
+
+    test('banner does not appear for topics from 2+ days ago', async ({ page }) => {
+        const twoDaysAgo = new Date();
+        twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+        const twoDaysAgoStr = `${twoDaysAgo.getFullYear()}-${String(twoDaysAgo.getMonth() + 1).padStart(2, '0')}-${String(twoDaysAgo.getDate()).padStart(2, '0')}`;
+
+        await page.addInitScript((oldDate) => {
+            localStorage.setItem(
+                'interview-trainer:today-plan',
+                JSON.stringify({
+                    planDate: oldDate,
+                    selectedTopicIds: ['javascript:closures'],
+                    studiedTopicIds: []
+                })
+            );
+        }, twoDaysAgoStr);
+
+        await page.goto('/#/plan');
+        await expect(page.locator('.plan__title')).toBeVisible({ timeout: 10_000 });
+        await expect(page.locator('.plan__carryover')).not.toBeVisible();
+    });
+
+    test('banner does not reappear after dismissal on page reload', async ({ page }) => {
+        await page.addInitScript((yesterday) => {
+            localStorage.setItem(
+                'interview-trainer:today-plan',
+                JSON.stringify({
+                    planDate: yesterday,
+                    selectedTopicIds: ['javascript:closures'],
+                    studiedTopicIds: []
+                })
+            );
+        }, yesterdayStr());
+
+        await page.goto('/#/plan');
+        await expect(page.locator('.plan__carryover')).toBeVisible({ timeout: 10_000 });
+        await page.locator('.plan__carryover-dismiss').click();
+
+        await page.reload();
+        await expect(page.locator('.plan__title')).toBeVisible({ timeout: 10_000 });
+        await expect(page.locator('.plan__carryover')).not.toBeVisible();
+    });
+});

--- a/src/app/core/services/today-plan.service.spec.ts
+++ b/src/app/core/services/today-plan.service.spec.ts
@@ -1,0 +1,169 @@
+import { TestBed } from '@angular/core/testing';
+
+import { formatLocalYmd } from '../../shared/utils/local-date.utils';
+import { TodayPlanService } from './today-plan.service';
+
+function yesterdayStr(): string {
+    const d = new Date();
+    d.setDate(d.getDate() - 1);
+    return formatLocalYmd(d);
+}
+
+function twoDaysAgoStr(): string {
+    const d = new Date();
+    d.setDate(d.getDate() - 2);
+    return formatLocalYmd(d);
+}
+
+function setTodayPlan(planDate: string, selectedTopicIds: string[], studiedTopicIds: string[]): void {
+    localStorage.setItem(
+        'interview-trainer:today-plan',
+        JSON.stringify({ planDate, selectedTopicIds, studiedTopicIds })
+    );
+}
+
+function setCarryover(fromDate: string, topicIds: string[]): void {
+    localStorage.setItem(
+        'interview-trainer:plan-carryover',
+        JSON.stringify({ fromDate, topicIds })
+    );
+}
+
+function getCarryoverRaw(): unknown {
+    const raw = localStorage.getItem('interview-trainer:plan-carryover');
+    return raw ? JSON.parse(raw) : null;
+}
+
+function setup(): TodayPlanService {
+    TestBed.configureTestingModule({});
+    return TestBed.inject(TodayPlanService);
+}
+
+describe('TodayPlanService — carryover detection', () => {
+    afterEach(() => {
+        TestBed.resetTestingModule();
+        localStorage.clear();
+    });
+
+    it('carryoverPending() is null when there is no prior plan', () => {
+        const svc = setup();
+        expect(svc.carryoverPending()).toBeNull();
+    });
+
+    it('carryoverPending() is null when plan is from today', () => {
+        setTodayPlan(formatLocalYmd(new Date()), ['javascript:closures'], []);
+        const svc = setup();
+        expect(svc.carryoverPending()).toBeNull();
+    });
+
+    it('carryoverPending() is null when all selected topics were studied', () => {
+        setTodayPlan(yesterdayStr(), ['javascript:closures'], ['javascript:closures']);
+        const svc = setup();
+        expect(svc.carryoverPending()).toBeNull();
+    });
+
+    it('carryoverPending() returns unfinished topics from yesterday', () => {
+        setTodayPlan(yesterdayStr(), ['javascript:closures', 'angular:signals'], ['angular:signals']);
+        const svc = setup();
+        const carryover = svc.carryoverPending();
+        expect(carryover).not.toBeNull();
+        expect(carryover!.topicIds).toEqual(['javascript:closures']);
+        expect(carryover!.fromDate).toBe(yesterdayStr());
+    });
+
+    it('carryoverPending() is null when plan is from 2+ days ago', () => {
+        setTodayPlan(twoDaysAgoStr(), ['javascript:closures'], []);
+        const svc = setup();
+        expect(svc.carryoverPending()).toBeNull();
+    });
+
+    it('resets today plan to empty when rolling over', () => {
+        setTodayPlan(yesterdayStr(), ['javascript:closures'], []);
+        const svc = setup();
+        expect(svc.selectedTopicIds()).toEqual([]);
+        expect(svc.studiedTopicIds()).toEqual([]);
+    });
+
+    it('reads previously saved carryover on subsequent loads without rollover', () => {
+        setCarryover(yesterdayStr(), ['javascript:closures', 'angular:signals']);
+        // Plan is already today's (no rollover), but carryover was saved from a previous load
+        setTodayPlan(formatLocalYmd(new Date()), [], []);
+        const svc = setup();
+        const carryover = svc.carryoverPending();
+        expect(carryover).not.toBeNull();
+        expect(carryover!.topicIds).toEqual(['javascript:closures', 'angular:signals']);
+    });
+
+    it('discards carryover older than yesterday', () => {
+        setCarryover(twoDaysAgoStr(), ['javascript:closures']);
+        const svc = setup();
+        expect(svc.carryoverPending()).toBeNull();
+    });
+});
+
+describe('TodayPlanService — acceptCarryover', () => {
+    afterEach(() => {
+        TestBed.resetTestingModule();
+        localStorage.clear();
+    });
+
+    it('adds carryover topics to today plan and clears carryoverPending', () => {
+        setTodayPlan(yesterdayStr(), ['javascript:closures', 'angular:signals'], []);
+        const svc = setup();
+        expect(svc.carryoverPending()).not.toBeNull();
+
+        svc.acceptCarryover();
+
+        expect(svc.carryoverPending()).toBeNull();
+        expect(svc.selectedTopicIds()).toContain('javascript:closures');
+        expect(svc.selectedTopicIds()).toContain('angular:signals');
+    });
+
+    it('does not add duplicate topics when accepting', () => {
+        setTodayPlan(yesterdayStr(), ['javascript:closures'], []);
+        const svc = setup();
+        svc.toggleTopicSelected('javascript:closures');
+        svc.acceptCarryover();
+
+        const ids = svc.selectedTopicIds();
+        expect(ids.filter((id) => id === 'javascript:closures')).toHaveLength(1);
+    });
+
+    it('clears the carryover from storage after accepting', () => {
+        setTodayPlan(yesterdayStr(), ['javascript:closures'], []);
+        const svc = setup();
+        svc.acceptCarryover();
+        expect(getCarryoverRaw()).toBeNull();
+    });
+
+    it('does nothing if carryoverPending is null', () => {
+        const svc = setup();
+        svc.acceptCarryover();
+        expect(svc.selectedTopicIds()).toEqual([]);
+    });
+});
+
+describe('TodayPlanService — dismissCarryover', () => {
+    afterEach(() => {
+        TestBed.resetTestingModule();
+        localStorage.clear();
+    });
+
+    it('clears carryoverPending without modifying today plan', () => {
+        setTodayPlan(yesterdayStr(), ['javascript:closures'], []);
+        const svc = setup();
+        expect(svc.carryoverPending()).not.toBeNull();
+
+        svc.dismissCarryover();
+
+        expect(svc.carryoverPending()).toBeNull();
+        expect(svc.selectedTopicIds()).toEqual([]);
+    });
+
+    it('clears the carryover from storage after dismissing', () => {
+        setTodayPlan(yesterdayStr(), ['javascript:closures'], []);
+        const svc = setup();
+        svc.dismissCarryover();
+        expect(getCarryoverRaw()).toBeNull();
+    });
+});

--- a/src/app/core/services/today-plan.service.ts
+++ b/src/app/core/services/today-plan.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, computed, inject, signal } from '@angular/core';
 
-import type { TodayPlanState } from '../../shared/models/today-plan.model';
+import type { PlanCarryover, TodayPlanState } from '../../shared/models/today-plan.model';
 import { formatLocalYmd } from '../../shared/utils/local-date.utils';
 import { isSociologyPlanTopicId } from '../../shared/utils/sociology-topic-key.utils';
 import { ActivityService } from './activity.service';
@@ -8,6 +8,7 @@ import { SociologyActivityService } from './sociology-activity.service';
 import { StorageService } from './storage.service';
 
 const TODAY_PLAN_KEY = 'today-plan';
+const CARRYOVER_KEY = 'plan-carryover';
 
 function emptyStateForToday(): TodayPlanState {
     return {
@@ -36,7 +37,10 @@ export class TodayPlanService {
     private readonly activityService = inject(ActivityService);
     private readonly sociologyActivityService = inject(SociologyActivityService);
 
+    // loadInitial() may write to CARRYOVER_KEY when a rollover is detected
     private readonly state = signal<TodayPlanState>(this.loadInitial());
+    // loadCarryover() reads from CARRYOVER_KEY after loadInitial() has potentially written it
+    readonly carryoverPending = signal<PlanCarryover | null>(this.loadCarryover());
 
     /** Resolved state after day rollover. */
     readonly plan = this.state.asReadonly();
@@ -115,6 +119,27 @@ export class TodayPlanService {
         });
     }
 
+    /** Add yesterday's unfinished topics to today's plan and clear the carryover prompt. */
+    acceptCarryover(): void {
+        const carryover = this.carryoverPending();
+        if (!carryover) return;
+        this.ensureCurrentDay();
+        const s = this.state();
+        const selectedSet = new Set(s.selectedTopicIds);
+        const newIds = carryover.topicIds.filter((id) => !selectedSet.has(id));
+        if (newIds.length > 0) {
+            this.save({ ...s, selectedTopicIds: [...s.selectedTopicIds, ...newIds] });
+        }
+        this.storage.set(CARRYOVER_KEY, null);
+        this.carryoverPending.set(null);
+    }
+
+    /** Dismiss the carryover prompt without adding topics. */
+    dismissCarryover(): void {
+        this.storage.set(CARRYOVER_KEY, null);
+        this.carryoverPending.set(null);
+    }
+
     private ensureCurrentDay(): void {
         const today = formatLocalYmd(new Date());
         const s = this.state();
@@ -135,6 +160,13 @@ export class TodayPlanService {
             return emptyStateForToday();
         }
         if (raw.planDate !== today) {
+            const yesterday = new Date();
+            yesterday.setDate(yesterday.getDate() - 1);
+            const studiedSet = new Set(raw.studiedTopicIds);
+            const unfinished = raw.selectedTopicIds.filter((id) => !studiedSet.has(id));
+            if (unfinished.length > 0 && raw.planDate === formatLocalYmd(yesterday)) {
+                this.storage.set(CARRYOVER_KEY, { fromDate: raw.planDate, topicIds: unfinished } satisfies PlanCarryover);
+            }
             const fresh = emptyStateForToday();
             this.storage.set(TODAY_PLAN_KEY, fresh);
             return fresh;
@@ -144,6 +176,31 @@ export class TodayPlanService {
             selectedTopicIds: [...new Set(raw.selectedTopicIds)],
             studiedTopicIds: [...new Set(raw.studiedTopicIds)]
         };
+    }
+
+    private loadCarryover(): PlanCarryover | null {
+        const yesterday = new Date();
+        yesterday.setDate(yesterday.getDate() - 1);
+        const yesterdayStr = formatLocalYmd(yesterday);
+        const raw = this.storage.get<unknown>(CARRYOVER_KEY);
+        if (!this.isCarryoverShape(raw)) return null;
+        if (raw.fromDate !== yesterdayStr) {
+            // Stale entry (older than yesterday); clear it
+            this.storage.set(CARRYOVER_KEY, null);
+            return null;
+        }
+        return raw;
+    }
+
+    private isCarryoverShape(raw: unknown): raw is PlanCarryover {
+        return (
+            typeof raw === 'object' &&
+            raw !== null &&
+            'fromDate' in raw &&
+            typeof (raw as PlanCarryover).fromDate === 'string' &&
+            'topicIds' in raw &&
+            Array.isArray((raw as PlanCarryover).topicIds)
+        );
     }
 
     private isPersistedShape(raw: unknown): raw is TodayPlanState {

--- a/src/app/features/plan/pages/plan-page/plan-page.component.html
+++ b/src/app/features/plan/pages/plan-page/plan-page.component.html
@@ -6,6 +6,22 @@
     <h1 id="plan-title" class="plan__title">{{ 'plan.title' | translate }}</h1>
     <p class="plan__intro">{{ 'plan.intro' | translate }}</p>
 
+    @if (carryoverTopicIds().length > 0) {
+        <div class="plan__carryover" role="status">
+            <p class="plan__carryover-msg">
+                {{ 'plan.carryoverPrompt' | translate: { count: carryoverTopicIds().length } }}
+            </p>
+            <div class="plan__carryover-actions">
+                <button type="button" class="plan__carryover-accept" (click)="acceptCarryover()">
+                    {{ 'plan.carryoverAccept' | translate }}
+                </button>
+                <button type="button" class="plan__carryover-dismiss" (click)="dismissCarryover()">
+                    {{ 'plan.carryoverDismiss' | translate }}
+                </button>
+            </div>
+        </div>
+    }
+
     @if (loadError()) {
         <p class="plan__message plan__message--error" role="alert">{{ 'plan.loadError' | translate }}</p>
     } @else if (loading()) {

--- a/src/app/features/plan/pages/plan-page/plan-page.component.scss
+++ b/src/app/features/plan/pages/plan-page/plan-page.component.scss
@@ -373,3 +373,72 @@
         max-width: 100%;
     }
 }
+
+.plan__carryover {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
+    padding: 1rem 1.25rem;
+    border-radius: 0.85rem;
+    border: 1px solid var(--it-accent);
+    background: var(--it-accent-dim);
+}
+
+.plan__carryover-msg {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.45;
+}
+
+.plan__carryover-actions {
+    display: flex;
+    gap: 0.65rem;
+    flex-wrap: wrap;
+}
+
+.plan__carryover-accept {
+    padding: 0.45rem 1rem;
+    border: none;
+    border-radius: 0.65rem;
+    background: var(--it-accent);
+    color: var(--it-on-accent);
+    font: inherit;
+    font-size: 0.88rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform 0.12s ease;
+}
+
+.plan__carryover-accept:hover {
+    transform: scale(1.02);
+}
+
+.plan__carryover-accept:focus-visible {
+    outline: 2px solid var(--it-focus);
+    outline-offset: 2px;
+    border-radius: 0.4rem;
+}
+
+.plan__carryover-dismiss {
+    padding: 0.45rem 1rem;
+    border: 1px solid var(--it-border);
+    border-radius: 0.65rem;
+    background: transparent;
+    color: var(--it-text-muted);
+    font: inherit;
+    font-size: 0.88rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.plan__carryover-dismiss:hover {
+    color: var(--it-text);
+    border-color: var(--it-text);
+}
+
+.plan__carryover-dismiss:focus-visible {
+    outline: 2px solid var(--it-focus);
+    outline-offset: 2px;
+    border-radius: 0.4rem;
+}

--- a/src/app/features/plan/pages/plan-page/plan-page.component.spec.ts
+++ b/src/app/features/plan/pages/plan-page/plan-page.component.spec.ts
@@ -6,6 +6,7 @@ import { Observable, of } from 'rxjs';
 
 import { PlanPageComponent } from './plan-page.component';
 import { TodayPlanService } from '../../../../core/services/today-plan.service';
+import { formatLocalYmd } from '../../../../shared/utils/local-date.utils';
 
 class StubLoader implements TranslateLoader {
     getTranslation(): Observable<TranslationObject> {
@@ -13,8 +14,11 @@ class StubLoader implements TranslateLoader {
     }
 }
 
-async function setup() {
+async function setup(storageEntries: Record<string, unknown> = {}) {
     localStorage.clear();
+    for (const [key, value] of Object.entries(storageEntries)) {
+        localStorage.setItem(`interview-trainer:${key}`, JSON.stringify(value));
+    }
     await TestBed.configureTestingModule({
         imports: [PlanPageComponent],
         providers: [
@@ -27,6 +31,9 @@ async function setup() {
     const fixture = TestBed.createComponent(PlanPageComponent);
     const component = fixture.componentInstance as unknown as {
         confirmMarkAllStudied: ReturnType<typeof import('@angular/core').signal<string | null>>;
+        carryoverTopicIds: () => string[];
+        acceptCarryover(): void;
+        dismissCarryover(): void;
         requestMarkAllStudied(key: string): void;
         confirmMarkAllStudiedTopics(): void;
         cancelMarkAllStudied(): void;
@@ -34,6 +41,12 @@ async function setup() {
     };
     fixture.detectChanges();
     return { fixture, component, plan: TestBed.inject(TodayPlanService) };
+}
+
+function yesterdayStr(): string {
+    const d = new Date();
+    d.setDate(d.getDate() - 1);
+    return formatLocalYmd(d);
 }
 
 describe('PlanPageComponent — bulk mark all as studied', () => {
@@ -110,5 +123,53 @@ describe('PlanPageComponent — bulk mark all as studied', () => {
         const { component } = await setup();
         component.requestMarkAllStudied('javascript__heading');
         expect(component.confirmMarkAllStudied()).toBe('javascript__heading');
+    });
+});
+
+describe('PlanPageComponent — carryover banner', () => {
+    afterEach(() => {
+        TestBed.resetTestingModule();
+        localStorage.clear();
+    });
+
+    it('carryoverTopicIds is empty when there is no carryover', async () => {
+        const { component } = await setup();
+        expect(component.carryoverTopicIds()).toEqual([]);
+    });
+
+    it('carryoverTopicIds reflects pending carryover topics (excluding sociology)', async () => {
+        const { component } = await setup({
+            'plan-carryover': { fromDate: yesterdayStr(), topicIds: ['javascript:closures', 'angular:signals'] }
+        });
+        expect(component.carryoverTopicIds()).toEqual(['javascript:closures', 'angular:signals']);
+    });
+
+    it('excludes sociology topics from carryoverTopicIds', async () => {
+        const { component } = await setup({
+            'plan-carryover': { fromDate: yesterdayStr(), topicIds: ['javascript:closures', 'sociology:topic:sub'] }
+        });
+        expect(component.carryoverTopicIds()).toEqual(['javascript:closures']);
+    });
+
+    it('acceptCarryover adds topics to today plan and clears carryoverTopicIds', async () => {
+        const { component, plan } = await setup({
+            'plan-carryover': { fromDate: yesterdayStr(), topicIds: ['javascript:closures'] }
+        });
+
+        component.acceptCarryover();
+
+        expect(component.carryoverTopicIds()).toEqual([]);
+        expect(plan.isSelected('javascript:closures')).toBe(true);
+    });
+
+    it('dismissCarryover clears carryoverTopicIds without adding to plan', async () => {
+        const { component, plan } = await setup({
+            'plan-carryover': { fromDate: yesterdayStr(), topicIds: ['javascript:closures'] }
+        });
+
+        component.dismissCarryover();
+
+        expect(component.carryoverTopicIds()).toEqual([]);
+        expect(plan.isSelected('javascript:closures')).toBe(false);
     });
 });

--- a/src/app/features/plan/pages/plan-page/plan-page.component.ts
+++ b/src/app/features/plan/pages/plan-page/plan-page.component.ts
@@ -132,6 +132,21 @@ export class PlanPageComponent {
         this.todayPlan.clearStudied(id);
     }
 
+    /** Unfinished topics from yesterday (JS/Angular only — sociology excluded). */
+    protected readonly carryoverTopicIds = computed(() => {
+        const carryover = this.todayPlan.carryoverPending();
+        if (!carryover) return [];
+        return carryover.topicIds.filter((id) => !isSociologyPlanTopicId(id));
+    });
+
+    protected acceptCarryover(): void {
+        this.todayPlan.acceptCarryover();
+    }
+
+    protected dismissCarryover(): void {
+        this.todayPlan.dismissCarryover();
+    }
+
     protected readonly confirmRemoveAll = signal(false);
 
     protected requestRemoveAll(): void {

--- a/src/app/shared/models/today-plan.model.ts
+++ b/src/app/shared/models/today-plan.model.ts
@@ -4,3 +4,9 @@ export interface TodayPlanState {
     selectedTopicIds: string[];
     studiedTopicIds: string[];
 }
+
+/** Persisted carry-over from the previous day's unfinished topics. */
+export interface PlanCarryover {
+    fromDate: string;
+    topicIds: string[];
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -199,7 +199,10 @@
         "markAllStudiedAria": "Mark all selected topics as studied",
         "markAllStudiedCatAria": "Mark all {{cat}} topics as studied",
         "markAllStudiedConfirm": "Mark all as studied?",
-        "markAllStudiedYes": "Yes, mark all"
+        "markAllStudiedYes": "Yes, mark all",
+        "carryoverPrompt": "You had {{count}} unfinished topic(s) from yesterday — add them to today's plan?",
+        "carryoverAccept": "Add to plan",
+        "carryoverDismiss": "Skip"
     },
     "heatmap": {
         "heading": "Activity",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -199,7 +199,10 @@
         "markAllStudiedAria": "Отметить все выбранные темы как изученные",
         "markAllStudiedCatAria": "Отметить все темы {{cat}} как изученные",
         "markAllStudiedConfirm": "Отметить все как изученные?",
-        "markAllStudiedYes": "Да, отметить"
+        "markAllStudiedYes": "Да, отметить",
+        "carryoverPrompt": "Вчера вы не завершили {{count}} тем(у) — добавить их в план на сегодня?",
+        "carryoverAccept": "Добавить в план",
+        "carryoverDismiss": "Пропустить"
     },
     "heatmap": {
         "heading": "Активность",


### PR DESCRIPTION
## Summary

- Detect unfinished plan topics (selected but not studied) on day rollover and save them to a `plan-carryover` localStorage key
- On the next app load, show a dismissible banner on the Plan page: "You had N unfinished topic(s) from yesterday — add them to today's plan?" with Accept / Skip actions
- Carryover only applies to topics from exactly the previous day (2+ days ago are silently discarded)
- Accepting/dismissing clears the carryover so the prompt appears at most once per rollover

## Files changed

| File | Change |
|------|--------|
| `src/app/shared/models/today-plan.model.ts` | Added `PlanCarryover` interface |
| `src/app/core/services/today-plan.service.ts` | Detect rollover in `loadInitial()`, save carryover; added `carryoverPending` signal, `acceptCarryover()`, `dismissCarryover()`, `loadCarryover()` |
| `src/app/core/services/today-plan.service.spec.ts` | New: 14 unit tests covering carryover detection, accept, and dismiss |
| `src/app/features/plan/pages/plan-page/plan-page.component.ts` | Expose `carryoverTopicIds` computed (filters sociology), `acceptCarryover()`, `dismissCarryover()` |
| `src/app/features/plan/pages/plan-page/plan-page.component.html` | Add carryover banner block before main content |
| `src/app/features/plan/pages/plan-page/plan-page.component.scss` | Styles for `.plan__carryover` banner |
| `src/app/features/plan/pages/plan-page/plan-page.component.spec.ts` | 5 new component tests for carryover banner |
| `src/assets/i18n/en.json` | Added `plan.carryoverPrompt`, `plan.carryoverAccept`, `plan.carryoverDismiss` |
| `src/assets/i18n/ru.json` | Russian translations for the same keys |
| `e2e/plan-carryover.spec.ts` | New: 5 Playwright e2e tests for the banner |
| `docs/issues-priority.md` | Marked #53 as ✅ Done |

## Acceptance criteria

- [x] Prompt only appears once per rollover (dismiss/accept clears the carryover from storage)
- [x] Does not apply to topics from 2+ days ago
- [x] If user confirms, unfinished topics are pre-selected in today's plan
- [x] If declined, plan starts empty as before

Closes #53

🤖 Generated with [mouse-fixes](https://github.com/ZhannaM85/mouse-fixes)
