### PR TITLE
Fix #44: Save and resume an incomplete quiz session

### DIFF
--- a/docs/issues-priority.md
+++ b/docs/issues-priority.md
@@ -33,7 +33,7 @@ Generated 2026-05-06. Based on labels, dependencies, and effort/value assessment
 |---|-------|-------|
 | ~~[#50](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/50)~~ | ~~Session length picker~~ | ✅ Done |
 | ~~[#53](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/53)~~ | ~~Carry over unfinished plan topics~~ | ✅ Done |
-| [#44](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/44) | Save and resume incomplete session | **Unlocks #60** — do before it |
+| ~~[#44](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/44)~~ | ~~Save and resume incomplete session~~ | ✅ Done |
 | [#60](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/60) | Resume session nudge on app load | Depends on #44 |
 
 ---

--- a/e2e/quiz-resume.spec.ts
+++ b/e2e/quiz-resume.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+
+const SNAPSHOT_KEY = 'interview-trainer:active-session';
+
+function makeSnapshot(questionNumber: number, total: number) {
+    const ids = Array.from({ length: total }, (_, i) => i + 1);
+    return {
+        queueIds: ids,
+        currentIndex: questionNumber - 1,
+        sessionMode: 'standard',
+        practiceScope: 'full',
+        topicsFocusParam: '',
+        sessionNailed: questionNumber - 1,
+        sessionPartial: 0,
+        sessionDidntKnow: 0,
+        sessionBestStreak: questionNumber - 1,
+        currentStreak: questionNumber - 1,
+        sessionTotal: total,
+        sessionStackTopicIds: ['javascript:closures'],
+        usingFallbackQueue: false,
+        savedAt: new Date().toISOString()
+    };
+}
+
+test.describe('Quiz page — resume session', () => {
+    test('shows resume banner when a snapshot exists', async ({ page }) => {
+        await page.addInitScript(({ key, value }) => {
+            localStorage.setItem(key, JSON.stringify(value));
+        }, { key: SNAPSHOT_KEY, value: makeSnapshot(3, 10) });
+
+        await page.goto('/#/quiz');
+
+        const banner = page.locator('.quiz__resume-banner');
+        await expect(banner).toBeVisible({ timeout: 10_000 });
+        await expect(banner).toContainText('3');
+        await expect(banner).toContainText('10');
+    });
+
+    test('does not show resume banner when no snapshot exists', async ({ page }) => {
+        await page.goto('/#/quiz');
+        await expect(page.locator('.quiz__session-picker')).toBeVisible({ timeout: 10_000 });
+        await expect(page.locator('.quiz__resume-banner')).not.toBeVisible();
+    });
+
+    test('dismissing resume banner hides it and clears localStorage', async ({ page }) => {
+        await page.addInitScript(({ key, value }) => {
+            localStorage.setItem(key, JSON.stringify(value));
+        }, { key: SNAPSHOT_KEY, value: makeSnapshot(2, 5) });
+
+        await page.goto('/#/quiz');
+        await expect(page.locator('.quiz__resume-banner')).toBeVisible({ timeout: 10_000 });
+
+        await page.locator('.quiz__resume-dismiss').click();
+        await expect(page.locator('.quiz__resume-banner')).not.toBeVisible();
+
+        const stored = await page.evaluate((k) => localStorage.getItem(k), SNAPSHOT_KEY);
+        expect(stored).toBeNull();
+    });
+
+    test('starting a new session hides the banner and clears localStorage', async ({ page }) => {
+        await page.addInitScript(({ key, value }) => {
+            localStorage.setItem(key, JSON.stringify(value));
+        }, { key: SNAPSHOT_KEY, value: makeSnapshot(2, 5) });
+
+        await page.goto('/#/quiz');
+        await expect(page.locator('.quiz__resume-banner')).toBeVisible({ timeout: 10_000 });
+
+        await page.locator('.quiz__session-mode-btn').first().click();
+        await expect(page.locator('.quiz__resume-banner')).not.toBeVisible();
+
+        const stored = await page.evaluate((k) => localStorage.getItem(k), SNAPSHOT_KEY);
+        expect(stored).toBeNull();
+    });
+});

--- a/src/app/core/services/question.service.ts
+++ b/src/app/core/services/question.service.ts
@@ -128,6 +128,16 @@ export class QuestionService {
         this.index = -1;
     }
 
+    getQueueIds(): number[] {
+        return this.queue.map((q) => q.id);
+    }
+
+    /** Restore a saved queue, positioning the cursor so the next getNextQuestion() returns questions[startIndex]. */
+    restoreQueue(questions: Question[], startIndex: number): void {
+        this.queue = [...questions];
+        this.index = startIndex - 1;
+    }
+
     /** Find a question by id from the latest mapped list (same order as `getQuestions()` emissions). */
     getQuestionByIdFromList(questions: Question[], id: number): Question | null {
         return questions.find((q) => q.id === id) ?? null;

--- a/src/app/features/quiz/pages/quiz-page/quiz-page.component.html
+++ b/src/app/features/quiz/pages/quiz-page/quiz-page.component.html
@@ -8,6 +8,19 @@
 
     @if (showSessionModePicker()) {
         <div class="quiz__session-picker card-phase" role="region" aria-labelledby="session-picker-title">
+            @if (resumeInfo(); as info) {
+                <div class="quiz__resume-banner" role="status" aria-label="{{ 'quiz.resumeBannerAria' | translate }}">
+                    <p class="quiz__resume-text">{{ 'quiz.resumeSession' | translate: { question: info.questionNumber, total: info.total } }}</p>
+                    <div class="quiz__resume-actions">
+                        <button type="button" class="quiz__resume-btn" (click)="resumeSession()">
+                            {{ 'quiz.resumeBtn' | translate }}
+                        </button>
+                        <button type="button" class="quiz__resume-dismiss" (click)="dismissResume()">
+                            {{ 'quiz.resumeDismiss' | translate }}
+                        </button>
+                    </div>
+                </div>
+            }
             <h2 id="session-picker-title" class="quiz__session-picker-title">{{ 'quiz.sessionPickerTitle' | translate }}</h2>
             <div class="quiz__session-picker-options" role="group" [attr.aria-label]="'quiz.sessionPickerOptionsAria' | translate">
                 <button

--- a/src/app/features/quiz/pages/quiz-page/quiz-page.component.scss
+++ b/src/app/features/quiz/pages/quiz-page/quiz-page.component.scss
@@ -588,3 +588,77 @@
     color: inherit;
     opacity: 0.8;
 }
+
+.quiz__resume-banner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    padding: 0.9rem 1rem;
+    border-radius: 0.75rem;
+    border: 1px solid var(--it-accent);
+    background: var(--it-accent-dim);
+    text-align: center;
+}
+
+.quiz__resume-text {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--it-accent);
+}
+
+.quiz__resume-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    width: 100%;
+}
+
+.quiz__resume-btn {
+    width: 100%;
+    min-height: 2.5rem;
+    padding: 0.45rem 1rem;
+    border-radius: 0.65rem;
+    border: none;
+    background: var(--it-accent);
+    color: var(--it-on-accent);
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform 0.12s ease;
+}
+
+.quiz__resume-btn:hover {
+    transform: scale(1.02);
+}
+
+.quiz__resume-btn:focus-visible {
+    outline: 2px solid var(--it-focus);
+    outline-offset: 2px;
+}
+
+.quiz__resume-dismiss {
+    width: 100%;
+    min-height: 2.2rem;
+    padding: 0.35rem 1rem;
+    border-radius: 0.65rem;
+    border: 1px solid var(--it-border);
+    background: transparent;
+    color: var(--it-text-muted);
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: border-color 0.12s ease, color 0.12s ease;
+}
+
+.quiz__resume-dismiss:hover {
+    border-color: var(--it-accent);
+    color: var(--it-accent);
+}
+
+.quiz__resume-dismiss:focus-visible {
+    outline: 2px solid var(--it-focus);
+    outline-offset: 2px;
+}

--- a/src/app/features/quiz/pages/quiz-page/quiz-page.component.spec.ts
+++ b/src/app/features/quiz/pages/quiz-page/quiz-page.component.spec.ts
@@ -6,6 +6,7 @@ import { Observable, of } from 'rxjs';
 
 import { QuizPageComponent, type SessionMode } from './quiz-page.component';
 import { QuestionService } from '../../../../core/services/question.service';
+import type { ActiveSessionSnapshot } from '../../../../shared/models/active-session.model';
 
 class StubLoader implements TranslateLoader {
     getTranslation(): Observable<TranslationObject> {
@@ -22,7 +23,11 @@ class StubLoader implements TranslateLoader {
                 sessionModeStandard: 'Standard',
                 sessionModeStandardDesc: '15 questions',
                 sessionModeDeep: 'Deep',
-                sessionModeDeepDesc: 'All due'
+                sessionModeDeepDesc: 'All due',
+                resumeSession: 'Resume ({{question}} of {{total}})',
+                resumeBtn: 'Resume',
+                resumeDismiss: 'Start new',
+                resumeBannerAria: 'Resume previous session'
             }
         });
     }
@@ -116,5 +121,118 @@ describe('QuizPageComponent — session mode picker', () => {
         expect(component.showSessionModePicker()).toBe(false);
         component.restartSession();
         expect(component.showSessionModePicker()).toBe(true);
+    });
+});
+
+describe('QuizPageComponent — session resume', () => {
+    const SNAPSHOT_KEY = 'interview-trainer:active-session';
+
+    const makeSnap = (partial?: Partial<ActiveSessionSnapshot>): ActiveSessionSnapshot => ({
+        queueIds: [1, 2, 3],
+        currentIndex: 1,
+        sessionMode: 'standard',
+        practiceScope: 'full',
+        topicsFocusParam: '',
+        sessionNailed: 1,
+        sessionPartial: 0,
+        sessionDidntKnow: 0,
+        sessionBestStreak: 1,
+        currentStreak: 1,
+        sessionTotal: 3,
+        sessionStackTopicIds: ['javascript:closures'],
+        usingFallbackQueue: false,
+        savedAt: new Date().toISOString(),
+        ...partial
+    });
+
+    beforeEach(async () => {
+        localStorage.clear();
+        await TestBed.configureTestingModule({
+            imports: [QuizPageComponent],
+            providers: testProviders
+        }).compileComponents();
+    });
+
+    afterEach(() => TestBed.resetTestingModule());
+
+    it('sets resumeInfo when a valid snapshot exists in localStorage', () => {
+        localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(makeSnap()));
+        const fixture = TestBed.createComponent(QuizPageComponent);
+        const component = fixture.componentInstance as unknown as {
+            resumeInfo: () => { questionNumber: number; total: number } | null;
+        };
+        expect(component.resumeInfo()).toEqual({ questionNumber: 2, total: 3 });
+    });
+
+    it('does not set resumeInfo when no snapshot exists', () => {
+        const fixture = TestBed.createComponent(QuizPageComponent);
+        const component = fixture.componentInstance as unknown as {
+            resumeInfo: () => { questionNumber: number; total: number } | null;
+        };
+        expect(component.resumeInfo()).toBeNull();
+    });
+
+    it('does not set resumeInfo when snapshot has empty queueIds', () => {
+        localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(makeSnap({ queueIds: [] })));
+        const fixture = TestBed.createComponent(QuizPageComponent);
+        const component = fixture.componentInstance as unknown as {
+            resumeInfo: () => { questionNumber: number; total: number } | null;
+        };
+        expect(component.resumeInfo()).toBeNull();
+    });
+
+    it('does not set resumeInfo when currentIndex is out of bounds', () => {
+        localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(makeSnap({ currentIndex: 10 })));
+        const fixture = TestBed.createComponent(QuizPageComponent);
+        const component = fixture.componentInstance as unknown as {
+            resumeInfo: () => { questionNumber: number; total: number } | null;
+        };
+        expect(component.resumeInfo()).toBeNull();
+    });
+
+    it('restores sessionMode from snapshot', () => {
+        localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(makeSnap({ sessionMode: 'quick' })));
+        const fixture = TestBed.createComponent(QuizPageComponent);
+        const component = fixture.componentInstance as unknown as {
+            sessionMode: () => SessionMode;
+        };
+        expect(component.sessionMode()).toBe('quick');
+    });
+
+    it('dismissResume clears resumeInfo and removes snapshot from localStorage', () => {
+        localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(makeSnap()));
+        const fixture = TestBed.createComponent(QuizPageComponent);
+        const component = fixture.componentInstance as unknown as {
+            resumeInfo: () => { questionNumber: number; total: number } | null;
+            dismissResume: () => void;
+        };
+        expect(component.resumeInfo()).not.toBeNull();
+        component.dismissResume();
+        expect(component.resumeInfo()).toBeNull();
+        expect(localStorage.getItem(SNAPSHOT_KEY)).toBeNull();
+    });
+
+    it('startSession clears snapshot and resumeInfo', () => {
+        localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(makeSnap()));
+        const fixture = TestBed.createComponent(QuizPageComponent);
+        const component = fixture.componentInstance as unknown as {
+            resumeInfo: () => { questionNumber: number; total: number } | null;
+            startSession: (mode: SessionMode) => void;
+        };
+        component.startSession('deep');
+        expect(component.resumeInfo()).toBeNull();
+        expect(localStorage.getItem(SNAPSHOT_KEY)).toBeNull();
+    });
+
+    it('restartSession clears snapshot and resumeInfo', () => {
+        localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(makeSnap()));
+        const fixture = TestBed.createComponent(QuizPageComponent);
+        const component = fixture.componentInstance as unknown as {
+            resumeInfo: () => { questionNumber: number; total: number } | null;
+            restartSession: () => void;
+        };
+        component.restartSession();
+        expect(component.resumeInfo()).toBeNull();
+        expect(localStorage.getItem(SNAPSHOT_KEY)).toBeNull();
     });
 });

--- a/src/app/features/quiz/pages/quiz-page/quiz-page.component.ts
+++ b/src/app/features/quiz/pages/quiz-page/quiz-page.component.ts
@@ -9,6 +9,7 @@ import { ProgressService, SCORE_BY_RATING } from '../../../../core/services/prog
 import { QuestionService } from '../../../../core/services/question.service';
 import { StorageService } from '../../../../core/services/storage.service';
 import { TodayPlanService } from '../../../../core/services/today-plan.service';
+import type { ActiveSessionSnapshot } from '../../../../shared/models/active-session.model';
 import type { Progress } from '../../../../shared/models/progress.model';
 import type { Question, QuestionCategory } from '../../../../shared/models/question.model';
 import { topicIdFromQuestion } from '../../../../shared/utils/topic-key.utils';
@@ -110,6 +111,8 @@ export class QuizPageComponent {
 
     protected readonly undoSnapshot = signal<UndoSnapshot | null>(null);
 
+    protected readonly resumeInfo = signal<{ questionNumber: number; total: number } | null>(null);
+
     /** Today's plan has topics selected but none marked studied yet — practice still uses full catalog. */
     protected readonly planFocusHint = computed(
         () => this.todayPlan.hasSelection() && !this.todayPlan.hasStudiedTopics()
@@ -181,6 +184,7 @@ export class QuizPageComponent {
 
     constructor() {
         this.todayPlan.syncCalendarDay();
+        this.checkForResumableSession();
 
         this.questionService
             .getQuestions()
@@ -297,6 +301,8 @@ export class QuizPageComponent {
     }
 
     protected startSession(mode: SessionMode): void {
+        this.clearSessionSnapshot();
+        this.resumeInfo.set(null);
         this.sessionMode.set(mode);
         this.storage.set('quiz-session-mode', mode);
         this.showSessionModePicker.set(false);
@@ -304,7 +310,65 @@ export class QuizPageComponent {
     }
 
     protected restartSession(): void {
+        this.clearSessionSnapshot();
+        this.resumeInfo.set(null);
         this.showSessionModePicker.set(true);
+    }
+
+    protected resumeSession(): void {
+        const snap = this.storage.get<ActiveSessionSnapshot>('active-session');
+        if (!snap) {
+            this.dismissResume();
+            return;
+        }
+        this.sessionMode.set(snap.sessionMode);
+        this.practiceScope.set(snap.practiceScope);
+        this.showSessionModePicker.set(false);
+        this.loading.set(true);
+        this.loadError.set(false);
+        this.sessionComplete.set(false);
+        this.showPlanTopicsCoveredDialog.set(false);
+        this.sessionTruncated.set(false);
+        this.phase.set('question');
+        this.feedbackSnapshot.set(null);
+        this.feedbackCtx.set(null);
+        this.undoSnapshot.set(null);
+        this.sessionNailed.set(snap.sessionNailed);
+        this.sessionPartial.set(snap.sessionPartial);
+        this.sessionDidntKnow.set(snap.sessionDidntKnow);
+        this.sessionBestStreak.set(snap.sessionBestStreak);
+        this.currentStreak = snap.currentStreak;
+        this.sessionTotal.set(snap.sessionTotal);
+        this.sessionStackTopicIds.set(snap.sessionStackTopicIds);
+        this.usingFallbackQueue.set(snap.usingFallbackQueue);
+        this.questionService.getQuestions().pipe(take(1)).subscribe({
+            next: (all) => {
+                const idMap = new Map(all.map((q) => [q.id, q]));
+                const queue = snap.queueIds
+                    .map((id) => idMap.get(id))
+                    .filter((q): q is Question => q != null);
+                if (queue.length === 0 || snap.currentIndex >= queue.length) {
+                    this.clearSessionSnapshot();
+                    this.resumeInfo.set(null);
+                    this.showSessionModePicker.set(true);
+                    this.loading.set(false);
+                    return;
+                }
+                this.questionService.restoreQueue(queue, snap.currentIndex);
+                this.sessionIndex.set(snap.currentIndex);
+                this.loading.set(false);
+                this.advanceToNextQuestion();
+            },
+            error: () => {
+                this.loadError.set(true);
+                this.loading.set(false);
+            }
+        });
+    }
+
+    protected dismissResume(): void {
+        this.clearSessionSnapshot();
+        this.resumeInfo.set(null);
     }
 
     protected switchToFullQuestionBank(): void {
@@ -331,6 +395,38 @@ export class QuizPageComponent {
         this.showPlanTopicsCoveredDialog.set(false);
         this.acceptPlanTopicFallback.set(true);
         this.loadQuiz();
+    }
+
+    private checkForResumableSession(): void {
+        const snap = this.storage.get<ActiveSessionSnapshot>('active-session');
+        if (snap && snap.queueIds.length > 0 && snap.currentIndex < snap.queueIds.length) {
+            this.resumeInfo.set({ questionNumber: snap.currentIndex + 1, total: snap.sessionTotal });
+            this.sessionMode.set(snap.sessionMode);
+        }
+    }
+
+    private saveSessionSnapshot(): void {
+        const snap: ActiveSessionSnapshot = {
+            queueIds: this.questionService.getQueueIds(),
+            currentIndex: this.sessionIndex() - 1,
+            sessionMode: this.sessionMode(),
+            practiceScope: this.practiceScope(),
+            topicsFocusParam: this.topicsFocusParam(),
+            sessionNailed: this.sessionNailed(),
+            sessionPartial: this.sessionPartial(),
+            sessionDidntKnow: this.sessionDidntKnow(),
+            sessionBestStreak: this.sessionBestStreak(),
+            currentStreak: this.currentStreak,
+            sessionTotal: this.sessionTotal(),
+            sessionStackTopicIds: this.sessionStackTopicIds(),
+            usingFallbackQueue: this.usingFallbackQueue(),
+            savedAt: new Date().toISOString()
+        };
+        this.storage.set('active-session', snap);
+    }
+
+    private clearSessionSnapshot(): void {
+        localStorage.removeItem('interview-trainer:active-session');
     }
 
     private rebuildFeedbackSnapshot(): void {
@@ -488,8 +584,11 @@ export class QuizPageComponent {
         this.feedbackCtx.set(null);
         if (next) {
             this.sessionIndex.update((i) => i + 1);
+            this.saveSessionSnapshot();
         }
         if (!next) {
+            this.clearSessionSnapshot();
+            this.resumeInfo.set(null);
             this.sessionComplete.set(true);
         }
     }

--- a/src/app/shared/models/active-session.model.ts
+++ b/src/app/shared/models/active-session.model.ts
@@ -1,0 +1,16 @@
+export interface ActiveSessionSnapshot {
+    queueIds: number[];
+    currentIndex: number;       // 0-based index into queueIds of the question the user was on
+    sessionMode: 'quick' | 'standard' | 'deep';
+    practiceScope: 'planFocused' | 'full' | 'studiedTopics';
+    topicsFocusParam: string;
+    sessionNailed: number;
+    sessionPartial: number;
+    sessionDidntKnow: number;
+    sessionBestStreak: number;
+    currentStreak: number;
+    sessionTotal: number;
+    sessionStackTopicIds: string[];
+    usingFallbackQueue: boolean;
+    savedAt: string;
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -317,7 +317,11 @@
         "sessionModeStandardDesc": "15 questions — balanced daily practice",
         "sessionModeDeep": "Deep",
         "sessionModeDeepDesc": "All due questions — full review session",
-        "sessionFewNote": "Only {{count}} questions were available — using all of them."
+        "sessionFewNote": "Only {{count}} questions were available — using all of them.",
+        "resumeSession": "Resume session (question {{question}} of {{total}})",
+        "resumeBtn": "Resume",
+        "resumeDismiss": "Start new session",
+        "resumeBannerAria": "Resume previous session"
     },
     "dashboard": {
         "title": "Interview Progress",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -317,7 +317,11 @@
         "sessionModeStandardDesc": "15 вопросов — сбалансированная ежедневная практика",
         "sessionModeDeep": "Углублённо",
         "sessionModeDeepDesc": "Все вопросы к повторению — полная сессия",
-        "sessionFewNote": "Доступно только {{count}} вопросов — используем все."
+        "sessionFewNote": "Доступно только {{count}} вопросов — используем все.",
+        "resumeSession": "Продолжить сессию (вопрос {{question}} из {{total}})",
+        "resumeBtn": "Продолжить",
+        "resumeDismiss": "Начать новую сессию",
+        "resumeBannerAria": "Продолжить предыдущую сессию"
     },
     "dashboard": {
         "title": "Прогресс по собеседованиям",


### PR DESCRIPTION
## Summary

- Added `ActiveSessionSnapshot` model and localStorage persistence (`active-session` key) — on every question advance the current queue, position, and session stats are snapshotted so the session can be resumed after a page close
- Added a "Resume session (question X of Y)" banner to the session picker that appears when a valid snapshot exists; the user can resume the exact question they were on or dismiss it and start fresh
- Snapshot is cleared automatically when the session ends normally, when a new session is started, or when the user explicitly dismisses the banner
- Added `getQueueIds()` and `restoreQueue()` to `QuestionService` to support restoring a queue at an arbitrary position without re-shuffling

## Files changed

| File | Change |
|------|--------|
| `src/app/shared/models/active-session.model.ts` | New model — `ActiveSessionSnapshot` interface |
| `src/app/core/services/question.service.ts` | Added `getQueueIds()` and `restoreQueue()` methods |
| `src/app/features/quiz/pages/quiz-page/quiz-page.component.ts` | Snapshot save/restore/clear logic; `resumeSession()` and `dismissResume()` methods |
| `src/app/features/quiz/pages/quiz-page/quiz-page.component.html` | Resume banner in session picker |
| `src/app/features/quiz/pages/quiz-page/quiz-page.component.scss` | Styles for `.quiz__resume-banner` and related elements |
| `src/app/features/quiz/pages/quiz-page/quiz-page.component.spec.ts` | Unit tests for snapshot detection, restore, and dismiss |
| `src/assets/i18n/en.json` | Added `quiz.resumeSession`, `quiz.resumeBtn`, `quiz.resumeDismiss`, `quiz.resumeBannerAria` |
| `src/assets/i18n/ru.json` | Same keys in Russian |
| `e2e/quiz-resume.spec.ts` | E2E tests: banner shown/hidden, dismiss, new session clears snapshot |
| `docs/issues-priority.md` | Marked #44 as done |

## Acceptance criteria

- [x] Closing and reopening the browser resumes at the exact question the user was on
- [x] Snapshot is not confused with a completed session (cleared on normal completion)
- [x] No more than one active session can exist at a time (single `active-session` key, overwritten on each advance)

Closes #44

🤖 Generated with [mouse-fixes](https://github.com/ZhannaM85/mouse-fixes)
