### PR TITLE
Fix #59: Add breakdown of accuracy by difficulty level

### DIFF
--- a/docs/issues-priority.md
+++ b/docs/issues-priority.md
@@ -44,7 +44,7 @@ Generated 2026-05-06. Based on labels, dependencies, and effort/value assessment
 |---|-------|-------|
 | ~~[#45](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/45)~~ | ~~Accuracy/confidence trend chart~~ | ✅ Done |
 | ~~[#46](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/46)~~ | ~~Per-question performance analytics~~ | ✅ Done |
-| [#59](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/59) | Accuracy breakdown by difficulty | Pairs well with #46 |
+| ~~[#59](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/59)~~ | ~~Accuracy breakdown by difficulty~~ | ✅ Done |
 | [#51](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/51) | Daily practice goals | #41 "Goal getter" achievement waits on this |
 | [#41](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/41) | More achievement badges | Do after #51 |
 

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -18,6 +18,24 @@ test.describe('Dashboard hardest questions', () => {
     });
 });
 
+test.describe('Dashboard difficulty breakdown', () => {
+    test('shows accuracy by difficulty card on dashboard', async ({ page }) => {
+        await page.goto('/#/dashboard');
+        await expect(
+            page.locator('text=/Accuracy by difficulty|Точность по уровню сложности/i')
+        ).toBeVisible({ timeout: 10_000 });
+    });
+
+    test('shows empty state when no practice data exists', async ({ page }) => {
+        await page.goto('/#/dashboard');
+        await expect(
+            page.locator(
+                'text=/No practice data yet — answer|Пока нет данных — ответьте/i'
+            )
+        ).toBeVisible({ timeout: 10_000 });
+    });
+});
+
 test.describe('Dashboard trend chart', () => {
     test('shows trend chart card on dashboard', async ({ page }) => {
         await page.goto('/#/dashboard');

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.html
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.html
@@ -188,6 +188,36 @@
                 }
             </article>
 
+            <article class="dashboard__card">
+                <h2 class="dashboard__card-title">{{ 'dashboard.difficultyBreakdown.title' | translate }}</h2>
+                @if (difficultyBreakdownView().length === 0) {
+                    <p class="dashboard__hint">{{ 'dashboard.difficultyBreakdown.empty' | translate }}</p>
+                } @else {
+                    <ul class="dashboard__diff-list" [attr.aria-label]="'dashboard.difficultyBreakdown.title' | translate">
+                        @for (entry of difficultyBreakdownView(); track entry.difficulty) {
+                            <li class="dashboard__diff-item">
+                                <div class="dashboard__diff-header">
+                                    <span class="dashboard__diff-label dashboard__diff-label--{{ entry.difficulty }}">
+                                        {{ ('difficulty.' + entry.difficulty) | translate }}
+                                    </span>
+                                    <span class="dashboard__diff-pct"
+                                        [class.dashboard__diff-pct--high]="entry.accuracyPct >= 70"
+                                        [class.dashboard__diff-pct--low]="entry.accuracyPct < 40"
+                                        [attr.aria-label]="'dashboard.difficultyBreakdown.accuracyAria' | translate: { level: ('difficulty.' + entry.difficulty | translate), pct: entry.accuracyPct }"
+                                    >{{ entry.accuracyPct }}%</span>
+                                </div>
+                                <div class="dashboard__diff-bar-track" aria-hidden="true">
+                                    <div class="dashboard__diff-bar dashboard__diff-bar--{{ entry.difficulty }}" [style.width.%]="entry.accuracyPct"></div>
+                                </div>
+                                <p class="dashboard__diff-attempts">
+                                    {{ 'dashboard.difficultyBreakdown.attempts' | translate: { count: entry.total } }}
+                                </p>
+                            </li>
+                        }
+                    </ul>
+                }
+            </article>
+
             <article class="dashboard__card dashboard__card--wide">
                 <app-trend-chart />
             </article>

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.scss
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.scss
@@ -352,6 +352,101 @@
     color: var(--it-text-muted);
 }
 
+.dashboard__diff-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+
+.dashboard__diff-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.dashboard__diff-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.dashboard__diff-label {
+    font-size: 0.78rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.15rem 0.5rem;
+    border-radius: 0.3rem;
+    background: var(--it-border);
+    color: var(--it-text-muted);
+}
+
+.dashboard__diff-label--beginner {
+    background: color-mix(in srgb, #22c55e 16%, var(--it-card));
+    color: color-mix(in srgb, #15803d 85%, currentColor);
+}
+
+.dashboard__diff-label--intermediate {
+    background: color-mix(in srgb, #f59e0b 16%, var(--it-card));
+    color: color-mix(in srgb, #b45309 85%, currentColor);
+}
+
+.dashboard__diff-label--advanced {
+    background: color-mix(in srgb, #ef4444 16%, var(--it-card));
+    color: color-mix(in srgb, #b91c1c 85%, currentColor);
+}
+
+.dashboard__diff-pct {
+    font-size: 0.95rem;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+    color: var(--it-text-muted);
+}
+
+.dashboard__diff-pct--high {
+    color: var(--it-heat-1-border);
+}
+
+.dashboard__diff-pct--low {
+    color: var(--it-error);
+}
+
+.dashboard__diff-bar-track {
+    height: 0.45rem;
+    border-radius: 1rem;
+    background: var(--it-border);
+    overflow: hidden;
+}
+
+.dashboard__diff-bar {
+    height: 100%;
+    border-radius: 1rem;
+    background: var(--it-text-muted);
+    transition: width 0.3s ease;
+}
+
+.dashboard__diff-bar--beginner {
+    background: color-mix(in srgb, #22c55e 65%, var(--it-card));
+}
+
+.dashboard__diff-bar--intermediate {
+    background: color-mix(in srgb, #f59e0b 65%, var(--it-card));
+}
+
+.dashboard__diff-bar--advanced {
+    background: color-mix(in srgb, #ef4444 65%, var(--it-card));
+}
+
+.dashboard__diff-attempts {
+    margin: 0;
+    font-size: 0.72rem;
+    color: var(--it-text-muted);
+}
+
 .dashboard__ratings-intro {
     margin-bottom: 1rem;
 }

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.spec.ts
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.spec.ts
@@ -11,7 +11,7 @@ import { Observable, of } from 'rxjs';
 import { ProgressService } from '../../../../core/services/progress.service';
 import { QuestionService } from '../../../../core/services/question.service';
 import type { Question } from '../../../../shared/models/question.model';
-import { DashboardPageComponent, type HardestQuestion } from './dashboard-page.component';
+import { DashboardPageComponent, type DifficultyAccuracyEntry, type HardestQuestion } from './dashboard-page.component';
 
 class StubLoader implements TranslateLoader {
     getTranslation(): Observable<TranslationObject> {
@@ -21,6 +21,7 @@ class StubLoader implements TranslateLoader {
 
 type ComponentInternals = {
     hardestQuestionsView: () => HardestQuestion[];
+    difficultyBreakdownView: () => DifficultyAccuracyEntry[];
 };
 
 const testProviders = [
@@ -140,5 +141,85 @@ describe('DashboardPageComponent — hardestQuestionsView', () => {
         }
 
         expect(component.hardestQuestionsView().length).toBe(8);
+    });
+});
+
+describe('DashboardPageComponent — difficultyBreakdownView', () => {
+    beforeEach(() => localStorage.clear());
+    afterEach(() => TestBed.resetTestingModule());
+
+    it('returns empty list when no questions are loaded', () => {
+        const { component } = setup([]);
+        expect(component.difficultyBreakdownView()).toEqual([]);
+    });
+
+    it('returns empty list when no progress exists', () => {
+        const { component } = setup([makeQuestion({ id: 1, difficulty: 'beginner' })]);
+        expect(component.difficultyBreakdownView()).toEqual([]);
+    });
+
+    it('only includes difficulty levels that have at least one answered question', () => {
+        const q1 = makeQuestion({ id: 1, difficulty: 'beginner' });
+        const q2 = makeQuestion({ id: 2, difficulty: 'advanced' });
+        const { component, progressService } = setup([q1, q2]);
+        progressService.recordSelfRating(1, 'nailed');
+
+        const result = component.difficultyBreakdownView();
+        expect(result.length).toBe(1);
+        expect(result[0].difficulty).toBe('beginner');
+    });
+
+    it('orders levels beginner → intermediate → advanced', () => {
+        const q1 = makeQuestion({ id: 1, difficulty: 'advanced' });
+        const q2 = makeQuestion({ id: 2, difficulty: 'beginner' });
+        const q3 = makeQuestion({ id: 3, difficulty: 'intermediate' });
+        const { component, progressService } = setup([q1, q2, q3]);
+        progressService.recordSelfRating(1, 'nailed');
+        progressService.recordSelfRating(2, 'nailed');
+        progressService.recordSelfRating(3, 'nailed');
+
+        const result = component.difficultyBreakdownView();
+        expect(result.map((e) => e.difficulty)).toEqual(['beginner', 'intermediate', 'advanced']);
+    });
+
+    it('computes accuracyPct correctly (all nailed)', () => {
+        const q = makeQuestion({ id: 10, difficulty: 'intermediate' });
+        const { component, progressService } = setup([q]);
+        progressService.recordSelfRating(10, 'nailed');
+        progressService.recordSelfRating(10, 'nailed');
+
+        const result = component.difficultyBreakdownView();
+        expect(result[0].accuracyPct).toBe(100);
+        expect(result[0].total).toBe(2);
+    });
+
+    it('computes accuracyPct correctly (mixed ratings)', () => {
+        const q = makeQuestion({ id: 20, difficulty: 'advanced' });
+        const { component, progressService } = setup([q]);
+        progressService.recordSelfRating(20, 'nailed');
+        progressService.recordSelfRating(20, 'didntKnow');
+        progressService.recordSelfRating(20, 'didntKnow');
+        progressService.recordSelfRating(20, 'didntKnow');
+
+        const result = component.difficultyBreakdownView();
+        expect(result[0].accuracyPct).toBe(25);
+        expect(result[0].total).toBe(4);
+    });
+
+    it('aggregates multiple questions of the same difficulty', () => {
+        const q1 = makeQuestion({ id: 30, difficulty: 'beginner' });
+        const q2 = makeQuestion({ id: 31, difficulty: 'beginner' });
+        const { component, progressService } = setup([q1, q2]);
+        progressService.recordSelfRating(30, 'nailed');
+        progressService.recordSelfRating(30, 'nailed');
+        progressService.recordSelfRating(31, 'didntKnow');
+        progressService.recordSelfRating(31, 'didntKnow');
+
+        const result = component.difficultyBreakdownView();
+        expect(result.length).toBe(1);
+        expect(result[0].difficulty).toBe('beginner');
+        expect(result[0].total).toBe(4);
+        expect(result[0].nailed).toBe(2);
+        expect(result[0].accuracyPct).toBe(50);
     });
 });

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.ts
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.ts
@@ -18,7 +18,7 @@ import type { AppBackup, BackupDiff } from '../../../../core/services/data-expor
 import { ProgressService } from '../../../../core/services/progress.service';
 import { QuestionService } from '../../../../core/services/question.service';
 import type { Progress } from '../../../../shared/models/progress.model';
-import type { Question } from '../../../../shared/models/question.model';
+import type { Question, QuestionDifficulty } from '../../../../shared/models/question.model';
 import { formatLocalYmd } from '../../../../shared/utils/local-date.utils';
 import { topicIdFromParts } from '../../../../shared/utils/topic-key.utils';
 import { ActivityHeatmapComponent } from '../../components/activity-heatmap/activity-heatmap.component';
@@ -52,6 +52,15 @@ export interface TopicStrengthEntry {
     partial: number;
     didntKnow: number;
     total: number;
+}
+
+export interface DifficultyAccuracyEntry {
+    difficulty: QuestionDifficulty;
+    nailed: number;
+    partial: number;
+    didntKnow: number;
+    total: number;
+    accuracyPct: number;
 }
 
 export interface DashboardStats {
@@ -231,6 +240,41 @@ export class DashboardPageComponent {
         }
         result.sort((a, b) => a.nailedPct - b.nailedPct || a.questionId - b.questionId);
         return result.slice(0, 8);
+    });
+
+    protected readonly difficultyBreakdownView = computed((): DifficultyAccuracyEntry[] => {
+        const qs = this.questionsSignal();
+        if (qs.length === 0) return [];
+        const byId = new Map(this.progressService.getProgress().map((p) => [p.questionId, p]));
+        const byDifficulty = new Map<QuestionDifficulty, { nailed: number; partial: number; didntKnow: number }>();
+        for (const q of qs) {
+            const p = byId.get(q.id);
+            if (!p) continue;
+            const nailed = p.nailedCount ?? 0;
+            const partial = p.partialCount ?? 0;
+            const didntKnow = p.didntKnowCount ?? 0;
+            if (nailed + partial + didntKnow === 0) continue;
+            const agg = byDifficulty.get(q.difficulty) ?? { nailed: 0, partial: 0, didntKnow: 0 };
+            agg.nailed += nailed;
+            agg.partial += partial;
+            agg.didntKnow += didntKnow;
+            byDifficulty.set(q.difficulty, agg);
+        }
+        const order: QuestionDifficulty[] = ['beginner', 'intermediate', 'advanced'];
+        return order
+            .filter((d) => byDifficulty.has(d))
+            .map((difficulty) => {
+                const agg = byDifficulty.get(difficulty)!;
+                const total = agg.nailed + agg.partial + agg.didntKnow;
+                return {
+                    difficulty,
+                    nailed: agg.nailed,
+                    partial: agg.partial,
+                    didntKnow: agg.didntKnow,
+                    total,
+                    accuracyPct: Math.round((agg.nailed / total) * 100)
+                };
+            });
     });
 
     protected toggleMetricHelp(which: 'accuracy' | 'confidence'): void {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -389,6 +389,12 @@
             "nailedPct": "{{pct}}% nailed",
             "attempts": "{{count}} attempts"
         },
+        "difficultyBreakdown": {
+            "title": "Accuracy by difficulty",
+            "empty": "No practice data yet — answer a few questions to see accuracy by difficulty level.",
+            "attempts": "{{count}} attempt(s)",
+            "accuracyAria": "{{level}}: {{pct}}% accuracy"
+        },
         "achievement": {
             "longerThanYesterday": "Studied longer than yesterday"
         },

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -389,6 +389,12 @@
             "nailedPct": "{{pct}}% отлично",
             "attempts": "{{count}} попыток"
         },
+        "difficultyBreakdown": {
+            "title": "Точность по уровню сложности",
+            "empty": "Пока нет данных — ответьте на несколько вопросов, чтобы увидеть точность по уровням.",
+            "attempts": "{{count}} попыт(ок)",
+            "accuracyAria": "{{level}}: точность {{pct}}%"
+        },
         "achievement": {
             "longerThanYesterday": "Занимались дольше, чем вчера"
         },


### PR DESCRIPTION
## Summary

- Added `difficultyBreakdownView` computed signal to the dashboard that joins `ProgressService` records with `Question.difficulty` and aggregates nailed/partial/didntKnow counts per difficulty level (beginner, intermediate, advanced)
- Added a new "Accuracy by difficulty" card to the dashboard template with a colour-coded bar chart comparing accuracy across difficulty levels; only levels with at least one answered question are shown
- Added SCSS styles and EN/RU translations for the new card

## Files changed

| File | Change |
|------|--------|
| `dashboard-page.component.ts` | Added `DifficultyAccuracyEntry` interface and `difficultyBreakdownView` computed signal |
| `dashboard-page.component.html` | Added accuracy-by-difficulty card with bar chart |
| `dashboard-page.component.scss` | Added styles for difficulty breakdown list, labels, and bars |
| `dashboard-page.component.spec.ts` | Added 6 unit tests covering `difficultyBreakdownView` |
| `src/assets/i18n/en.json` | Added `dashboard.difficultyBreakdown.*` translation keys |
| `src/assets/i18n/ru.json` | Added Russian translations for the new keys |
| `e2e/dashboard.spec.ts` | Added 2 e2e tests for the difficulty breakdown card |
| `docs/issues-priority.md` | Marked #59 as done |

## Acceptance criteria

- [x] Only shows difficulty levels that have at least one answered question
- [x] Updates reactively as new answers come in (uses signals — `difficultyBreakdownView` is a `computed()` that reads `progressService.getProgress()` which reads a signal)

Closes #59

🤖 Generated with [mouse-fixes](https://github.com/ZhannaM85/mouse-fixes)
