### PR TITLE
Fix #51: Add daily practice goals and progress toward them

### DIFF
--- a/docs/issues-priority.md
+++ b/docs/issues-priority.md
@@ -45,7 +45,7 @@ Generated 2026-05-06. Based on labels, dependencies, and effort/value assessment
 | ~~[#45](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/45)~~ | ~~Accuracy/confidence trend chart~~ | ✅ Done |
 | ~~[#46](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/46)~~ | ~~Per-question performance analytics~~ | ✅ Done |
 | ~~[#59](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/59)~~ | ~~Accuracy breakdown by difficulty~~ | ✅ Done |
-| [#51](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/51) | Daily practice goals | #41 "Goal getter" achievement waits on this |
+| ~~[#51](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/51)~~ | ~~Daily practice goals~~ | ✅ Done |
 | [#41](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/41) | More achievement badges | Do after #51 |
 
 ---

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -79,3 +79,28 @@ test.describe('Dashboard trend chart', () => {
         await expect(buttons.nth(1)).not.toHaveClass(/trend-chart__window-btn--active/);
     });
 });
+
+test.describe('Dashboard daily goal', () => {
+    test('shows daily goal card with default goal of 10', async ({ page }) => {
+        await page.goto('/#/dashboard');
+        const card = page.locator('[data-testid="daily-goal-card"]');
+        await expect(card).toBeVisible({ timeout: 10_000 });
+        await expect(card).toContainText(/0 \/ 10|Daily goal|Дневная цель/i);
+    });
+
+    test('daily goal input is present with default value 10', async ({ page }) => {
+        await page.goto('/#/dashboard');
+        const input = page.locator('#dashboard-daily-goal-input');
+        await expect(input).toBeVisible({ timeout: 10_000 });
+        await expect(input).toHaveValue('10');
+    });
+
+    test('changing the goal input updates the displayed goal', async ({ page }) => {
+        await page.goto('/#/dashboard');
+        const input = page.locator('#dashboard-daily-goal-input');
+        await expect(input).toBeVisible({ timeout: 10_000 });
+        await input.fill('20');
+        await input.dispatchEvent('change');
+        await expect(page.locator('[data-testid="daily-goal-card"]')).toContainText(/20/);
+    });
+});

--- a/src/app/core/services/activity.service.ts
+++ b/src/app/core/services/activity.service.ts
@@ -72,6 +72,12 @@ export class ActivityService {
         return (row?.questionsAnswered ?? 0) > 0;
     });
 
+    /** Number of questions answered today. Reactive — updates as activity is recorded. */
+    readonly todayQuestionsAnswered = computed(() => {
+        const row = this.byDate().get(formatLocalYmd(new Date()));
+        return row?.questionsAnswered ?? 0;
+    });
+
     /**
      * Sum of `activeSeconds` across all stored days (lifetime approximate).
      * Initialized once from stored data; updated incrementally in addActiveSeconds()

--- a/src/app/core/services/user-preferences.service.spec.ts
+++ b/src/app/core/services/user-preferences.service.spec.ts
@@ -1,0 +1,71 @@
+import { TestBed } from '@angular/core/testing';
+
+import { StorageService } from './storage.service';
+import { UserPreferencesService } from './user-preferences.service';
+
+function setup() {
+    TestBed.configureTestingModule({});
+    const service = TestBed.inject(UserPreferencesService);
+    const storage = TestBed.inject(StorageService);
+    return { service, storage };
+}
+
+describe('UserPreferencesService', () => {
+    beforeEach(() => localStorage.clear());
+    afterEach(() => TestBed.resetTestingModule());
+
+    it('defaults dailyGoal to 10 when no stored value', () => {
+        const { service } = setup();
+        expect(service.dailyGoal()).toBe(10);
+    });
+
+    it('loads dailyGoal from localStorage if present', () => {
+        localStorage.setItem('interview-trainer:user-preferences', JSON.stringify({ dailyGoal: 20 }));
+        const { service } = setup();
+        expect(service.dailyGoal()).toBe(20);
+    });
+
+    it('setDailyGoal updates the signal', () => {
+        const { service } = setup();
+        service.setDailyGoal(15);
+        expect(service.dailyGoal()).toBe(15);
+    });
+
+    it('setDailyGoal persists the new value to localStorage', () => {
+        const { service, storage } = setup();
+        service.setDailyGoal(25);
+        const stored = storage.get<{ dailyGoal: number }>('user-preferences');
+        expect(stored?.dailyGoal).toBe(25);
+    });
+
+    it('clamps goal to minimum of 1', () => {
+        const { service } = setup();
+        service.setDailyGoal(0);
+        expect(service.dailyGoal()).toBe(1);
+    });
+
+    it('clamps goal to maximum of 200', () => {
+        const { service } = setup();
+        service.setDailyGoal(999);
+        expect(service.dailyGoal()).toBe(200);
+    });
+
+    it('rounds non-integer values', () => {
+        const { service } = setup();
+        service.setDailyGoal(7.6);
+        expect(service.dailyGoal()).toBe(8);
+    });
+
+    it('ignores NaN', () => {
+        const { service } = setup();
+        service.setDailyGoal(NaN);
+        expect(service.dailyGoal()).toBe(10);
+    });
+
+    it('goal can be changed multiple times without resetting to default', () => {
+        const { service } = setup();
+        service.setDailyGoal(5);
+        service.setDailyGoal(12);
+        expect(service.dailyGoal()).toBe(12);
+    });
+});

--- a/src/app/core/services/user-preferences.service.ts
+++ b/src/app/core/services/user-preferences.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, inject, signal } from '@angular/core';
+
+import { StorageService } from './storage.service';
+
+const PREFS_KEY = 'user-preferences';
+const DEFAULT_DAILY_GOAL = 10;
+const MIN_DAILY_GOAL = 1;
+const MAX_DAILY_GOAL = 200;
+
+interface UserPreferences {
+    dailyGoal: number;
+}
+
+@Injectable({
+    providedIn: 'root'
+})
+export class UserPreferencesService {
+    private readonly storage = inject(StorageService);
+
+    private readonly _dailyGoal = signal<number>(this.loadDailyGoal());
+    readonly dailyGoal = this._dailyGoal.asReadonly();
+
+    setDailyGoal(n: number): void {
+        const clamped = Math.max(MIN_DAILY_GOAL, Math.min(MAX_DAILY_GOAL, Math.round(n)));
+        if (!Number.isFinite(clamped)) {
+            return;
+        }
+        this._dailyGoal.set(clamped);
+        this.persist();
+    }
+
+    private loadDailyGoal(): number {
+        const raw = this.storage.get<UserPreferences>(PREFS_KEY);
+        if (raw && typeof raw.dailyGoal === 'number' && Number.isFinite(raw.dailyGoal)) {
+            return Math.max(MIN_DAILY_GOAL, Math.min(MAX_DAILY_GOAL, Math.round(raw.dailyGoal)));
+        }
+        return DEFAULT_DAILY_GOAL;
+    }
+
+    private persist(): void {
+        this.storage.set(PREFS_KEY, { dailyGoal: this._dailyGoal() } satisfies UserPreferences);
+    }
+}

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.html
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.html
@@ -360,6 +360,35 @@
                 </p>
             </article>
 
+            <article class="dashboard__card" data-testid="daily-goal-card">
+                @let dg = dailyGoalView();
+                <h2 class="dashboard__card-title">{{ 'dashboard.dailyGoal.title' | translate }}</h2>
+                <p class="dashboard__daily-goal-progress" aria-live="polite">
+                    {{ 'dashboard.dailyGoal.progress' | translate: { answered: dg.answered, goal: dg.goal } }}
+                </p>
+                <app-progress-bar [value]="dg.answered" [max]="dg.goal" [label]="'dashboard.dailyGoal.title' | translate" />
+                @if (dg.reached) {
+                    <p class="dashboard__achievement dashboard__achievement--goal" role="status" aria-live="polite">
+                        🎉 {{ 'dashboard.dailyGoal.reached' | translate }}
+                    </p>
+                }
+                <div class="dashboard__daily-goal-edit">
+                    <label class="dashboard__daily-goal-label" for="dashboard-daily-goal-input">
+                        {{ 'dashboard.dailyGoal.editLabel' | translate }}
+                    </label>
+                    <input
+                        id="dashboard-daily-goal-input"
+                        type="number"
+                        class="dashboard__daily-goal-input"
+                        [value]="dg.goal"
+                        min="1"
+                        max="200"
+                        (change)="onDailyGoalChange($event)"
+                        [attr.aria-label]="'dashboard.dailyGoal.editLabel' | translate"
+                    />
+                </div>
+            </article>
+
             <article class="dashboard__card dashboard__card--wide">
                 <app-activity-heatmap />
             </article>

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.scss
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.scss
@@ -157,6 +157,47 @@
     margin-bottom: 0.75rem;
 }
 
+.dashboard__daily-goal-progress {
+    margin: 0 0 0.65rem;
+    font-size: 1.15rem;
+    font-weight: 700;
+}
+
+.dashboard__achievement--goal {
+    margin-top: 0.65rem;
+}
+
+.dashboard__daily-goal-edit {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    margin-top: 1rem;
+    flex-wrap: wrap;
+}
+
+.dashboard__daily-goal-label {
+    font-size: 0.82rem;
+    color: var(--it-text-muted);
+    font-weight: 600;
+}
+
+.dashboard__daily-goal-input {
+    width: 5rem;
+    padding: 0.3rem 0.5rem;
+    border-radius: 0.4rem;
+    border: 1px solid var(--it-border);
+    background: var(--it-card);
+    color: var(--it-text);
+    font-size: 0.9rem;
+    font-family: inherit;
+    text-align: center;
+
+    &:focus {
+        outline: 2px solid var(--it-accent);
+        outline-offset: 1px;
+    }
+}
+
 .dashboard__metric--streak {
     margin-bottom: 0.35rem;
 }

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.spec.ts
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.spec.ts
@@ -8,8 +8,10 @@ import {
 } from '@ngx-translate/core';
 import { Observable, of } from 'rxjs';
 
+import { ActivityService } from '../../../../core/services/activity.service';
 import { ProgressService } from '../../../../core/services/progress.service';
 import { QuestionService } from '../../../../core/services/question.service';
+import { UserPreferencesService } from '../../../../core/services/user-preferences.service';
 import type { Question } from '../../../../shared/models/question.model';
 import { DashboardPageComponent, type DifficultyAccuracyEntry, type HardestQuestion } from './dashboard-page.component';
 
@@ -22,6 +24,7 @@ class StubLoader implements TranslateLoader {
 type ComponentInternals = {
     hardestQuestionsView: () => HardestQuestion[];
     difficultyBreakdownView: () => DifficultyAccuracyEntry[];
+    dailyGoalView: () => { answered: number; goal: number; pct: number; reached: boolean };
 };
 
 const testProviders = [
@@ -221,5 +224,63 @@ describe('DashboardPageComponent — difficultyBreakdownView', () => {
         expect(result[0].total).toBe(4);
         expect(result[0].nailed).toBe(2);
         expect(result[0].accuracyPct).toBe(50);
+    });
+});
+
+describe('DashboardPageComponent — dailyGoalView', () => {
+    beforeEach(() => localStorage.clear());
+    afterEach(() => TestBed.resetTestingModule());
+
+    it('shows default goal of 10 and 0 answered when no activity', () => {
+        const { component } = setup([]);
+        const view = component.dailyGoalView();
+        expect(view.goal).toBe(10);
+        expect(view.answered).toBe(0);
+        expect(view.reached).toBe(false);
+    });
+
+    it('reflects today\'s answered questions in the view', () => {
+        const { component } = setup([]);
+        const activityService = TestBed.inject(ActivityService);
+        activityService.bumpQuestionsAnswered(3);
+        const view = component.dailyGoalView();
+        expect(view.answered).toBe(3);
+    });
+
+    it('reached is true when answered >= goal', () => {
+        const { component } = setup([]);
+        const activityService = TestBed.inject(ActivityService);
+        const prefsService = TestBed.inject(UserPreferencesService);
+        prefsService.setDailyGoal(5);
+        activityService.bumpQuestionsAnswered(5);
+        const view = component.dailyGoalView();
+        expect(view.reached).toBe(true);
+    });
+
+    it('reached is false when answered < goal', () => {
+        const { component } = setup([]);
+        const activityService = TestBed.inject(ActivityService);
+        const prefsService = TestBed.inject(UserPreferencesService);
+        prefsService.setDailyGoal(10);
+        activityService.bumpQuestionsAnswered(7);
+        const view = component.dailyGoalView();
+        expect(view.reached).toBe(false);
+    });
+
+    it('pct is capped at 100 even when answered exceeds goal', () => {
+        const { component } = setup([]);
+        const activityService = TestBed.inject(ActivityService);
+        const prefsService = TestBed.inject(UserPreferencesService);
+        prefsService.setDailyGoal(5);
+        activityService.bumpQuestionsAnswered(10);
+        const view = component.dailyGoalView();
+        expect(view.pct).toBe(100);
+    });
+
+    it('updates goal reactively when UserPreferencesService changes', () => {
+        const { component } = setup([]);
+        const prefsService = TestBed.inject(UserPreferencesService);
+        prefsService.setDailyGoal(20);
+        expect(component.dailyGoalView().goal).toBe(20);
     });
 });

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.ts
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.ts
@@ -17,6 +17,7 @@ import { DataExportService } from '../../../../core/services/data-export.service
 import type { AppBackup, BackupDiff } from '../../../../core/services/data-export.service';
 import { ProgressService } from '../../../../core/services/progress.service';
 import { QuestionService } from '../../../../core/services/question.service';
+import { UserPreferencesService } from '../../../../core/services/user-preferences.service';
 import type { Progress } from '../../../../shared/models/progress.model';
 import type { Question, QuestionDifficulty } from '../../../../shared/models/question.model';
 import { formatLocalYmd } from '../../../../shared/utils/local-date.utils';
@@ -85,9 +86,18 @@ export class DashboardPageComponent {
     private readonly questionService = inject(QuestionService);
     private readonly activityService = inject(ActivityService);
     private readonly dataExportService = inject(DataExportService);
+    protected readonly userPreferencesService = inject(UserPreferencesService);
 
     /** Inline help for Accuracy / Confidence (tap icon on mobile; hover title still works on desktop). */
     protected readonly openMetricHelp = signal<'accuracy' | 'confidence' | null>(null);
+
+    /** Daily goal progress view: answered / goal / reached. */
+    protected readonly dailyGoalView = computed(() => {
+        const answered = this.activityService.todayQuestionsAnswered();
+        const goal = this.userPreferencesService.dailyGoal();
+        const pct = Math.min(100, Math.round((answered / goal) * 100));
+        return { answered, goal, pct, reached: answered >= goal };
+    });
 
     /** Illustrative bar max (10,000 h in seconds) — not a literal goal. */
     protected readonly tenKHoursSeconds = 10_000 * 3600;
@@ -279,6 +289,14 @@ export class DashboardPageComponent {
 
     protected toggleMetricHelp(which: 'accuracy' | 'confidence'): void {
         this.openMetricHelp.update((current) => (current === which ? null : which));
+    }
+
+    protected onDailyGoalChange(event: Event): void {
+        const input = event.target as HTMLInputElement;
+        const n = parseInt(input.value, 10);
+        if (Number.isFinite(n) && n > 0) {
+            this.userPreferencesService.setDailyGoal(n);
+        }
     }
 
     @HostListener('document:pointerdown', ['$event'])

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -398,6 +398,12 @@
         "achievement": {
             "longerThanYesterday": "Studied longer than yesterday"
         },
+        "dailyGoal": {
+            "title": "Daily goal",
+            "progress": "{{answered}} / {{goal}} questions today",
+            "reached": "Goal reached! Great work!",
+            "editLabel": "Change goal:"
+        },
         "dataBackup": {
             "title": "Data backup",
             "exportBtn": "Export data",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -398,6 +398,12 @@
         "achievement": {
             "longerThanYesterday": "Занимались дольше, чем вчера"
         },
+        "dailyGoal": {
+            "title": "Дневная цель",
+            "progress": "{{answered}} / {{goal}} вопросов сегодня",
+            "reached": "Цель достигнута! Отличная работа!",
+            "editLabel": "Изменить цель:"
+        },
         "dataBackup": {
             "title": "Резервная копия данных",
             "exportBtn": "Экспортировать данные",


### PR DESCRIPTION
## Summary

- Add `UserPreferencesService` to store a configurable daily question goal (default 10) under the `user-preferences` localStorage key; goal is clamped to 1–200 and persists across sessions
- Add `todayQuestionsAnswered` reactive computed signal to `ActivityService` so components can reactively read today's count without reading the full map
- Add a **Daily Goal** card to the dashboard showing a progress bar (`answered / goal questions today`), a 🎉 congratulatory message when the goal is reached, and an inline number input to change the goal at any time without resetting today's progress
- Add bilingual translations (`en.json` / `ru.json`) for all daily goal UI strings

## Files changed

| File | Change |
|------|--------|
| `src/app/core/services/user-preferences.service.ts` | New service — persists `dailyGoal` under `user-preferences` localStorage key |
| `src/app/core/services/user-preferences.service.spec.ts` | Unit tests for `UserPreferencesService` (9 tests) |
| `src/app/core/services/activity.service.ts` | Add `todayQuestionsAnswered` reactive computed signal |
| `src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.ts` | Inject `UserPreferencesService`, add `dailyGoalView` computed, add `onDailyGoalChange` handler |
| `src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.html` | Add daily goal card with progress bar, congratulatory indicator, and goal input |
| `src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.scss` | Styles for daily goal progress, input, and achievement indicator |
| `src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.spec.ts` | Add `dailyGoalView` unit tests (6 tests); import new services |
| `src/assets/i18n/en.json` | Add `dashboard.dailyGoal.*` translation keys |
| `src/assets/i18n/ru.json` | Add Russian translations for daily goal keys |
| `e2e/dashboard.spec.ts` | Add e2e tests for the daily goal card |
| `docs/issues-priority.md` | Mark #51 as done |

## Acceptance criteria

- [x] Goal can be changed at any time without resetting progress (inline input updates `UserPreferencesService`; `ActivityService` today count is unaffected)
- [x] Progress resets at calendar day rollover (uses same `formatLocalYmd(new Date())` key as `ActivityService`)
- [x] Works alongside existing streak tracking (no changes to streak logic)

Closes #51

🤖 Generated with [mouse-fixes](https://github.com/ZhannaM85/mouse-fixes)
