### PR TITLE
Fix #98: Make 'Hardest Questions' items on dashboard navigate to study guide

### DIFF
--- a/docs/issues-priority.md
+++ b/docs/issues-priority.md
@@ -15,7 +15,7 @@ Generated 2026-05-06. Based on labels, dependencies, and effort/value assessment
 | ~~[#54](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/54)~~ | ~~Bulk "Mark all as studied" in plan~~ | ✅ Done |
 | ~~[#40](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/40)~~ | ~~Difficulty filter in study guide~~ | ✅ Done — [PR #73](https://github.com/ZhannaM85/interview-trainer-angular-app/pull/73) |
 | ~~[#39](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/39)~~ | ~~Full-text search in study guide~~ | ✅ Done |
-| [#98](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/98) | Make 'Hardest Questions' items on dashboard navigate to study guide | Low-effort nav improvement; data already available on each item |
+| ~~[#98](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/98)~~ | ~~Make 'Hardest Questions' items on dashboard navigate to study guide~~ | ✅ Done |
 
 ---
 

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -16,6 +16,34 @@ test.describe('Dashboard hardest questions', () => {
             )
         ).toBeVisible({ timeout: 10_000 });
     });
+
+    test('clicking a hardest question item navigates to the study page filtered to its topic', async ({ page }) => {
+        // Seed progress for question 1 (javascript / this) with 3 didntKnow attempts
+        await page.addInitScript(() => {
+            const progress = [
+                {
+                    questionId: 1,
+                    nailedCount: 0,
+                    partialCount: 0,
+                    didntKnowCount: 3,
+                    lastAnswered: '2026-01-01',
+                    nextReview: '2026-01-02'
+                }
+            ];
+            localStorage.setItem('interview-trainer:progress', JSON.stringify(progress));
+        });
+
+        await page.goto('/#/dashboard');
+
+        const firstItem = page.locator('.dashboard__hardest-item').first();
+        await expect(firstItem).toBeVisible({ timeout: 10_000 });
+
+        await firstItem.click();
+
+        await expect(page).toHaveURL(/study/, { timeout: 5_000 });
+        const url = decodeURIComponent(page.url());
+        expect(url).toContain('topics=javascript');
+    });
 });
 
 test.describe('Dashboard difficulty breakdown', () => {

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.html
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.html
@@ -164,24 +164,30 @@
                 } @else {
                     <ul class="dashboard__hardest-list">
                         @for (item of hardestQuestionsView(); track item.questionId) {
-                            <li class="dashboard__hardest-item">
-                                <div class="dashboard__hardest-meta">
-                                    <span
-                                        class="dashboard__best-badge dashboard__best-badge--{{ item.category }}"
-                                        aria-hidden="true"
-                                    >{{ ('category.' + item.category) | translate }}</span>
-                                </div>
-                                <p class="dashboard__hardest-question">{{ item.question }}</p>
-                                <div class="dashboard__hardest-stats">
-                                    <span
-                                        class="dashboard__hardest-pct"
-                                        [class.dashboard__hardest-pct--low]="item.nailedPct < 40"
-                                        [attr.aria-label]="'dashboard.hardestQuestions.nailedPct' | translate: { pct: item.nailedPct }"
-                                    >{{ item.nailedPct }}%</span>
-                                    <span class="dashboard__hardest-attempts">{{
-                                        'dashboard.hardestQuestions.attempts' | translate: { count: item.total }
-                                    }}</span>
-                                </div>
+                            <li>
+                                <a
+                                    class="dashboard__hardest-item"
+                                    routerLink="/study"
+                                    [queryParams]="{ topics: item.category + ':' + item.subtopic }"
+                                >
+                                    <div class="dashboard__hardest-meta">
+                                        <span
+                                            class="dashboard__best-badge dashboard__best-badge--{{ item.category }}"
+                                            aria-hidden="true"
+                                        >{{ ('category.' + item.category) | translate }}</span>
+                                    </div>
+                                    <p class="dashboard__hardest-question">{{ item.question }}</p>
+                                    <div class="dashboard__hardest-stats">
+                                        <span
+                                            class="dashboard__hardest-pct"
+                                            [class.dashboard__hardest-pct--low]="item.nailedPct < 40"
+                                            [attr.aria-label]="'dashboard.hardestQuestions.nailedPct' | translate: { pct: item.nailedPct }"
+                                        >{{ item.nailedPct }}%</span>
+                                        <span class="dashboard__hardest-attempts">{{
+                                            'dashboard.hardestQuestions.attempts' | translate: { count: item.total }
+                                        }}</span>
+                                    </div>
+                                </a>
                             </li>
                         }
                     </ul>

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.scss
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.scss
@@ -354,6 +354,22 @@
     border-radius: 0.5rem;
     background: var(--it-dashboard-streak-bg);
     border: 1px solid var(--it-dashboard-streak-border);
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+    transition:
+        border-color 0.12s ease,
+        background-color 0.12s ease;
+}
+
+.dashboard__hardest-item:hover {
+    border-color: color-mix(in srgb, var(--it-accent) 35%, var(--it-dashboard-streak-border));
+    background: color-mix(in srgb, var(--it-accent) 8%, var(--it-dashboard-streak-bg));
+}
+
+.dashboard__hardest-item:focus-visible {
+    outline: 2px solid var(--it-focus);
+    outline-offset: 2px;
 }
 
 .dashboard__hardest-meta {

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.spec.ts
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.spec.ts
@@ -145,6 +145,35 @@ describe('DashboardPageComponent — hardestQuestionsView', () => {
 
         expect(component.hardestQuestionsView().length).toBe(8);
     });
+
+    it('exposes category and subtopic for link construction', () => {
+        const q = makeQuestion({ id: 20, category: 'angular', subtopic: 'signals' });
+        const { component, progressService } = setup([q]);
+        progressService.recordSelfRating(20, 'didntKnow');
+        progressService.recordSelfRating(20, 'partial');
+        progressService.recordSelfRating(20, 'didntKnow');
+
+        const results = component.hardestQuestionsView();
+        expect(results.length).toBe(1);
+        expect(results[0].category).toBe('angular');
+        expect(results[0].subtopic).toBe('signals');
+    });
+
+    it('renders an anchor link to the study page with the correct topic query param', () => {
+        const q = makeQuestion({ id: 20, category: 'javascript', subtopic: 'closures' });
+        const { fixture, progressService } = setup([q]);
+        progressService.recordSelfRating(20, 'didntKnow');
+        progressService.recordSelfRating(20, 'didntKnow');
+        progressService.recordSelfRating(20, 'didntKnow');
+        fixture.detectChanges();
+
+        const link = fixture.nativeElement.querySelector('.dashboard__hardest-item') as HTMLAnchorElement;
+        expect(link).toBeTruthy();
+        expect(link.tagName.toLowerCase()).toBe('a');
+        const href = decodeURIComponent(link.getAttribute('href') ?? '');
+        expect(href).toContain('/study');
+        expect(href).toContain('javascript:closures');
+    });
 });
 
 describe('DashboardPageComponent — difficultyBreakdownView', () => {


### PR DESCRIPTION
﻿## Summary

- Wrap each item in the Hardest Questions list in a `<a routerLink="/study">` anchor so users can click through directly to the Study Guide filtered to that question's topic (`?topics=category:subtopic`)
- Add hover and focus-visible styles to `.dashboard__hardest-item` for clear link affordance (border + background colour shift on hover, focus ring on keyboard navigation)
- Unit test: verifies `hardestQuestionsView()` exposes `category`/`subtopic` correctly and that the rendered anchor has a `/study?topics=…` href
- E2E test: seeds progress for a known question in localStorage, navigates to the dashboard, clicks the hardest question item, and asserts the URL changes to `/study?topics=javascript…`

## Files changed

| File | Change |
|------|--------|
| `dashboard-page.component.html` | Replace `<li class="dashboard__hardest-item">` with `<li><a class="dashboard__hardest-item" routerLink="/study" [queryParams]="…">` |
| `dashboard-page.component.scss` | Add `text-decoration: none`, `cursor: pointer`, hover border/background, and `focus-visible` outline to `.dashboard__hardest-item` |
| `dashboard-page.component.spec.ts` | Two new unit tests: category/subtopic exposure and rendered anchor href |
| `e2e/dashboard.spec.ts` | New E2E test: seed localStorage, click item, assert navigation to `/study?topics=…` |
| `docs/issues-priority.md` | Mark #98 as done |

## Acceptance criteria

- [x] Each item in the Hardest Questions list is a clickable `<a>` link
- [x] Clicking navigates to `/study?topics=<category>:<subtopic>`
- [x] Hover and focus-visible styles make the affordance clear
- [x] All unit tests pass (`ng test`)
- [x] E2E test covers the navigation flow

Closes #98

🤖 Generated with [mouse-fixes](https://github.com/ZhannaM85/mouse-fixes)
