### PR TITLE
fix: guard getQuestions() with filter(qs => qs.length > 0) to prevent…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ __screenshots__/
 # Claude Code
 .claude/
 
+# mouse-fixes tool state (local run artifacts, never commit)
+.mouse-fixes/
+
 # System files
 .DS_Store
 Thumbs.db

--- a/docs/issues-priority.md
+++ b/docs/issues-priority.md
@@ -8,7 +8,7 @@ Generated 2026-05-06. Based on labels, dependencies, and effort/value assessment
 
 | # | Issue | Notes |
 |---|-------|-------|
-| [#100](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/100) | Quiz session sometimes starts with only 1 question after picking session length | Intermittent; likely race condition in `loadQuiz()` |
+| ~~[#100](https://github.com/ZhannaM85/interview-trainer-angular-app/issues/100)~~ | ~~Quiz session sometimes starts with only 1 question after picking session length~~ | ✅ Done — [PR #101](https://github.com/ZhannaM85/interview-trainer-angular-app/pull/101) |
 
 ---
 

--- a/src/app/features/quiz/pages/quiz-page/quiz-page.component.ts
+++ b/src/app/features/quiz/pages/quiz-page/quiz-page.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, HostListener, computed, inject, sig
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
-import { distinctUntilChanged, map, take } from 'rxjs';
+import { distinctUntilChanged, filter, map, take } from 'rxjs';
 
 import { AchievementService } from '../../../../core/services/achievement.service';
 import { ActivityService } from '../../../../core/services/activity.service';
@@ -350,7 +350,7 @@ export class QuizPageComponent {
         this.sessionTotal.set(snap.sessionTotal);
         this.sessionStackTopicIds.set(snap.sessionStackTopicIds);
         this.usingFallbackQueue.set(snap.usingFallbackQueue);
-        this.questionService.getQuestions().pipe(take(1)).subscribe({
+        this.questionService.getQuestions().pipe(filter((qs) => qs.length > 0), take(1)).subscribe({
             next: (all) => {
                 const idMap = new Map(all.map((q) => [q.id, q]));
                 const queue = snap.queueIds
@@ -520,7 +520,7 @@ export class QuizPageComponent {
         this.interviewReadySession.set(false);
         this.questionService
             .getQuestions()
-            .pipe(take(1))
+            .pipe(filter((qs) => qs.length > 0), take(1))
             .subscribe({
                 next: (all) => {
                     const scope = this.practiceScope();
@@ -567,11 +567,23 @@ export class QuizPageComponent {
                         this.acceptPlanTopicFallback.set(false);
                     }
                     this.usingFallbackQueue.set(useFallback);
-                    const queue = fullBankMode ? candidate : useFallback ? candidate : due;
+                    let queue = fullBankMode ? candidate : useFallback ? candidate : due;
                     const limit = SESSION_MODE_LIMIT[this.sessionMode()];
                     this.sessionTruncated.set(
                         limit != null && queue.length < limit && queue.length > 0
                     );
+                    // When the due queue is smaller than the session limit, pad it with
+                    // non-due questions so the user always gets a full session.
+                    // This prevents 1-question sessions when only a few items are due.
+                    if (!fullBankMode && !useFallback && limit != null && queue.length > 0 && queue.length < limit) {
+                        const queueIdSet = new Set(queue.map((q) => q.id));
+                        const extras = candidate.filter((q) => !queueIdSet.has(q.id));
+                        for (let i = extras.length - 1; i > 0; i--) {
+                            const j = Math.floor(Math.random() * (i + 1));
+                            [extras[i], extras[j]] = [extras[j], extras[i]];
+                        }
+                        queue = [...queue, ...extras.slice(0, limit - queue.length)];
+                    }
                     const finalQueue = this.questionService.initializeQueue(queue, limit);
                     this.sessionTotal.set(finalQueue.length);
                     this.sessionIndex.set(0);


### PR DESCRIPTION
Closes #100

… race condition

Issue #100: quiz session sometimes starts with only 1 question.

Root causes fixed:
1. Race condition: take(1) could capture an early empty or partial emission from combineLatest([rawQuestions\$, activeLocale\$, customQuestions\$]) before the HTTP response arrived. Added filter(qs => qs.length > 0) before take(1) in both loadQuiz() and resumeSession() to skip empty emissions.

2. Thin due-queue: when fewer questions are due than the session limit (e.g. 1 due question for a 5-question Quick session), useFallback was not triggered — the session started with only the due questions. Added padding logic that tops up the due queue with shuffled non-due questions up to the session limit.

🐭 Generated with [mouse-fixes](https://github.com/ZhannaM85/mouse-fixes)